### PR TITLE
fixed IOException handling when attempt state files are opened.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,8 @@ subprojects {
     }
 
     dependencies {
-        compile  'org.embulk:embulk-core:0.6.0'
-        provided 'org.embulk:embulk-core:0.6.0'
+        compile  'org.embulk:embulk-core:0.6.11'
+        provided 'org.embulk:embulk-core:0.6.11'
         compile 'org.apache.hadoop:hadoop-client:2.6.0'
         testCompile 'junit:junit:4.+'
     }

--- a/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/EmbulkMapReduce.java
+++ b/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/EmbulkMapReduce.java
@@ -101,7 +101,8 @@ public class EmbulkMapReduce
                 config.get(CK_TASK));
     }
 
-    public static Injector newEmbulkInstance(Configuration config) {
+    public static Injector newEmbulkInstance(Configuration config)
+    {
         ConfigSource systemConfig = getSystemConfig(config);
         return new EmbulkService(systemConfig).getInjector();
     }

--- a/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/EmbulkMapReduce.java
+++ b/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/EmbulkMapReduce.java
@@ -1,6 +1,5 @@
 package org.embulk.executor.mapreduce;
 
-import java.io.EOFException;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.concurrent.ExecutionException;
@@ -146,13 +145,8 @@ public class EmbulkMapReduce
             Path stateDir, TaskAttemptID id, ModelManager modelManager) throws IOException
     {
         Path path = new Path(stateDir, id.toString());
-
-        try (FSDataInputStream in = path.getFileSystem(config).open(path)) { // throw IOException
-            return AttemptState.readFrom(in, modelManager); // throw EOFException
-        } catch (EOFException e) {
-            throw e;
-        } catch (IOException e) {
-            throw new EOFException("Cannot open the attempt state file.");
+        try (FSDataInputStream in = path.getFileSystem(config).open(path)) {
+            return AttemptState.readFrom(in, modelManager);
         }
     }
 

--- a/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/EmbulkMapReduce.java
+++ b/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/EmbulkMapReduce.java
@@ -1,5 +1,6 @@
 package org.embulk.executor.mapreduce;
 
+import java.io.EOFException;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.concurrent.ExecutionException;
@@ -145,8 +146,13 @@ public class EmbulkMapReduce
             Path stateDir, TaskAttemptID id, ModelManager modelManager) throws IOException
     {
         Path path = new Path(stateDir, id.toString());
-        try (FSDataInputStream in = path.getFileSystem(config).open(path)) {
-            return AttemptState.readFrom(in, modelManager);
+
+        try (FSDataInputStream in = path.getFileSystem(config).open(path)) { // throw IOException
+            return AttemptState.readFrom(in, modelManager); // throw EOFException
+        } catch (EOFException e) {
+            throw e;
+        } catch (IOException e) {
+            throw new EOFException("Cannot open the attempt state file.");
         }
     }
 

--- a/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/EmbulkMapReduce.java
+++ b/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/EmbulkMapReduce.java
@@ -168,6 +168,8 @@ public class EmbulkMapReduce
 
                         @Override
                         public boolean isRetryableException(Exception exception) {
+                            // EOFException should not be retried because it's not temporal error
+                            // instead. getAttemptReports() handles it.
                             return !(exception instanceof EOFException);
                         }
 


### PR DESCRIPTION
During a job execution, some attempt state files opening fails. I got the following stacktrace:

```
2015-06-12_18:35:43.66892 Caused by: java.io.IOException: Cannot obtain block length for LocatedBlock{BP-1103246775-(masked_ip)-1429296572579:blk_1074251068_510244; getBlockSize()=0; corrupt=false; offset=0; locs=[(masked_ip):50010, (masked_ip):50010]; storageIDs=[DS-67dcac1f-21bc-4a83-8c51-6ec4a427c319, DS-49f6e452-4cc6-400b-89c5-98919c45b642]; storageTypes=[DISK, DISK]}
2015-06-12_18:35:43.66898        at org.apache.hadoop.hdfs.DFSInputStream.readBlockLength(DFSInputStream.java:359)
2015-06-12_18:35:43.66902        at org.apache.hadoop.hdfs.DFSInputStream.fetchLocatedBlocksAndGetLastBlockLength(DFSInputStream.java:301)
2015-06-12_18:35:43.66907        at org.apache.hadoop.hdfs.DFSInputStream.openInfo(DFSInputStream.java:238)
2015-06-12_18:35:43.66911        at org.apache.hadoop.hdfs.DFSInputStream.<init>(DFSInputStream.java:231)
2015-06-12_18:35:43.66916        at org.apache.hadoop.hdfs.DFSClient.open(DFSClient.java:1498)
2015-06-12_18:35:43.66920        at org.apache.hadoop.hdfs.DistributedFileSystem$3.doCall(DistributedFileSystem.java:302)
2015-06-12_18:35:43.66925        at org.apache.hadoop.hdfs.DistributedFileSystem$3.doCall(DistributedFileSystem.java:298)
2015-06-12_18:35:43.66930        at org.apache.hadoop.fs.FileSystemLinkResolver.resolve(FileSystemLinkResolver.java:81)
2015-06-12_18:35:43.66934        at org.apache.hadoop.hdfs.DistributedFileSystem.open(DistributedFileSystem.java:298)
2015-06-12_18:35:43.66939        at org.apache.hadoop.fs.FileSystem.open(FileSystem.java:766)
2015-06-12_18:35:43.66944        at org.embulk.executor.mapreduce.EmbulkMapReduce.readAttemptStateFile(EmbulkMapReduce.java:148)
2015-06-12_18:35:43.66948        at org.embulk.executor.mapreduce.MapReduceExecutor.getAttemptReports(MapReduceExecutor.java:382)
2015-06-12_18:35:43.66953        at org.embulk.executor.mapreduce.MapReduceExecutor.updateProcessState(MapReduceExecutor.java:296)
2015-06-12_18:35:43.66957        at org.embulk.executor.mapreduce.MapReduceExecutor.run(MapReduceExecutor.java:224)
2015-06-12_18:35:43.66963        ... 40 more
```
