### PR TITLE
skip the failure of attempt state file open retry

### DIFF
--- a/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/EmbulkMapReduce.java
+++ b/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/EmbulkMapReduce.java
@@ -155,9 +155,9 @@ public class EmbulkMapReduce
         final Path path = new Path(stateDir, id.toString());
         try {
             return retryExecutor()
-                    .withRetryLimit(10)
-                    .withInitialRetryWait(3000)
-                    .withMaxRetryWait(60 * 1000)
+                    .withRetryLimit(5)
+                    .withInitialRetryWait(2000) // 2 seconds
+                    .withMaxRetryWait(20000) // 20 seconds
                     .runInterruptible(new Retryable<AttemptState>() {
                         @Override
                         public AttemptState call() throws IOException {

--- a/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/EmbulkMapReduce.java
+++ b/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/EmbulkMapReduce.java
@@ -149,8 +149,7 @@ public class EmbulkMapReduce
     }
 
     public static AttemptState readAttemptStateFile(final Configuration config,
-            Path stateDir, TaskAttemptID id, final ModelManager modelManager)
-            throws IOException, RetryGiveupException
+            Path stateDir, TaskAttemptID id, final ModelManager modelManager) throws IOException
     {
         final Logger log = Exec.getLogger(EmbulkMapReduce.class);
         final Path path = new Path(stateDir, id.toString());
@@ -186,7 +185,8 @@ public class EmbulkMapReduce
                         }
                     });
         } catch (RetryGiveupException e) {
-            throw e;
+            Throwables.propagateIfInstanceOf(e.getCause(), IOException.class);
+            throw Throwables.propagate(e.getCause());
         } catch (InterruptedException e) {
             throw new InterruptedIOException();
         }

--- a/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/EmbulkMapReduce.java
+++ b/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/EmbulkMapReduce.java
@@ -169,7 +169,7 @@ public class EmbulkMapReduce
                         @Override
                         public boolean isRetryableException(Exception exception) {
                             // EOFException should not be retried because it's not temporal error
-                            // instead. getAttemptReports() handles it.
+                            // instead. It is handled by caller.
                             return !(exception instanceof EOFException);
                         }
 
@@ -185,6 +185,8 @@ public class EmbulkMapReduce
                         }
                     });
         } catch (RetryGiveupException e) {
+            // If IOException causes the retry, it is thrown and should be handled by caller.
+            // Otherwise, RuntimeException is thrown.
             Throwables.propagateIfInstanceOf(e.getCause(), IOException.class);
             throw Throwables.propagate(e.getCause());
         } catch (InterruptedException e) {

--- a/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/EmbulkMapReduce.java
+++ b/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/EmbulkMapReduce.java
@@ -149,7 +149,8 @@ public class EmbulkMapReduce
     }
 
     public static AttemptState readAttemptStateFile(final Configuration config,
-            Path stateDir, TaskAttemptID id, final ModelManager modelManager) throws IOException
+            Path stateDir, TaskAttemptID id, final ModelManager modelManager)
+            throws IOException, RetryGiveupException
     {
         final Logger log = Exec.getLogger(EmbulkMapReduce.class);
         final Path path = new Path(stateDir, id.toString());
@@ -185,8 +186,7 @@ public class EmbulkMapReduce
                         }
                     });
         } catch (RetryGiveupException e) {
-            Throwables.propagateIfInstanceOf(e.getCause(), IOException.class);
-            throw Throwables.propagate(e.getCause());
+            throw e;
         } catch (InterruptedException e) {
             throw new InterruptedIOException();
         }

--- a/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/MapReduceExecutor.java
+++ b/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/MapReduceExecutor.java
@@ -221,12 +221,12 @@ public class MapReduceExecutor
                             job.mapProgress() * 100, job.reduceProgress() * 100));
                 Thread.sleep(interval);
 
-                updateProcessState(job, mapTaskCount, stateDir, state, modelManager, true);
+                updateProcessState(job, mapTaskCount, stateDir, state, modelManager);
             }
 
             log.info(String.format("map %.1f%% reduce %.1f%%",
                         job.mapProgress() * 100, job.reduceProgress() * 100));
-            updateProcessState(job, mapTaskCount, stateDir, state, modelManager, false);
+            updateProcessState(job, mapTaskCount, stateDir, state, modelManager);
 
             Counters counters = job.getCounters();
             if (counters != null) {
@@ -291,9 +291,9 @@ public class MapReduceExecutor
     }
 
     private void updateProcessState(Job job, int mapTaskCount, Path stateDir,
-            ProcessState state, ModelManager modelManager, boolean skipUpdate) throws IOException
+            ProcessState state, ModelManager modelManager) throws IOException
     {
-        List<AttemptReport> reports = getAttemptReports(job.getConfiguration(), stateDir, modelManager, skipUpdate);
+        List<AttemptReport> reports = getAttemptReports(job.getConfiguration(), stateDir, modelManager);
 
         for (AttemptReport report : reports) {
             if (report == null) {
@@ -374,22 +374,20 @@ public class MapReduceExecutor
     private static final int TASK_EVENT_FETCH_SIZE = 100;
 
     private static List<AttemptReport> getAttemptReports(Configuration config,
-            Path stateDir, ModelManager modelManager, boolean skipUpdate) throws IOException
+            Path stateDir, ModelManager modelManager) throws IOException
     {
+        Logger log = Exec.getLogger(MapReduceExecutor.class);
         ImmutableList.Builder<AttemptReport> builder = ImmutableList.builder();
         for (TaskAttemptID aid : EmbulkMapReduce.listAttempts(config, stateDir)) {
             try {
                 AttemptState state = EmbulkMapReduce.readAttemptStateFile(config,
                         stateDir, aid, modelManager);
                 builder.add(new AttemptReport(aid, state));
-            } catch (EOFException ex) {  // plus Not Found exception
+            } catch (IOException ex) {  // plus Not Found exception
+                log.warn(ex.getMessage(), ex);
+                // returns AttemptReport that has null AttemptState if IOException is caught.
+                // The null AttemptState should be handled by caller.
                 builder.add(new AttemptReport(aid, null));
-            } catch (IOException ex) {
-                if (skipUpdate) {
-                    builder.add(new AttemptReport(aid, null));
-                } else {
-                    throw ex;
-                }
             }
         }
         return builder.build();

--- a/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/MapReduceExecutor.java
+++ b/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/MapReduceExecutor.java
@@ -48,7 +48,6 @@ import org.embulk.spi.ProcessState;
 import org.embulk.spi.TaskState;
 import org.embulk.spi.Schema;
 import org.embulk.spi.time.Timestamp;
-import org.embulk.spi.util.RetryExecutor.RetryGiveupException;
 
 public class MapReduceExecutor
         implements ExecutorPlugin
@@ -385,12 +384,11 @@ public class MapReduceExecutor
                 builder.add(new AttemptReport(aid, state));
             } catch (EOFException ex) {  // plus Not Found exception
                 builder.add(new AttemptReport(aid, null));
-            } catch (RetryGiveupException ex) {
+            } catch (IOException ex) {
                 if (skipUpdate) {
                     builder.add(new AttemptReport(aid, null));
                 } else {
-                    Throwables.propagateIfInstanceOf(ex.getCause(), IOException.class);
-                    throw Throwables.propagate(ex.getCause());
+                    throw ex;
                 }
             }
         }


### PR DESCRIPTION
This ticket is the continuation of #2. The count of the file open retry sometimes exceeds the threshold, default 10.
### Problem

The reason why the file open error occurs is:
1) The file cannot be opened temporarily.
2) The file that caused the temporal error (or the corrupted file) is used by retry every time.

1) was fixed by #2. But 2) sometimes occurred. Because the attempt files are associated to containers (map/reduce tasks). If a certain map task is killed by some reasons (e.g. preemption), the map task will be retried later as new map task. The new task creates new attempt file. But the name of the file is different from the killed map task's one. #2's retry mechanism is not efficient in this case. Because it retries to open the same named file. Since the old corrupted file is not recovered by the task, same error always occurs. 
### Solution

When a job is running, we can skip the update of the attemp state files if the IOException occurred.
