### PR TITLE
delete state_path dir if a job succeeded.

### DIFF
--- a/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/MapReduceExecutor.java
+++ b/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/MapReduceExecutor.java
@@ -232,6 +232,15 @@ public class MapReduceExecutor
             if (counters != null) {
                 log.info(counters.toString());
             }
+
+            // delete state dir
+            try {
+                if (job.isSuccessful()) {
+                    stateDir.getFileSystem(job.getConfiguration()).delete(stateDir, true);
+                }
+            } catch (IOException ex) {
+                log.warn(String.format("Unable to delete stateDir %s", stateDir), ex);
+            }
         } catch (IOException | InterruptedException | ClassNotFoundException e) {
             throw Throwables.propagate(e);
         }


### PR DESCRIPTION
Since state_path directories are not deleted automatically, they are left on HDFS. Users need to delete them manually. This patch is to delete state_path directory on HDFS when the job successfully finished.
