### PR TITLE
make mapreduce_service_class configurable v2

### DIFF
--- a/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/EmbulkMapReduce.java
+++ b/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/EmbulkMapReduce.java
@@ -118,7 +118,7 @@ public class EmbulkMapReduce
                 obj = new EmbulkService(systemConfig);
             } else {
                 Class<?> serviceClass = Class.forName(serviceClassName);
-                obj = serviceClass.getConstructor(ConfigSource.class).newInstance(config);
+                obj = serviceClass.getConstructor(ConfigSource.class).newInstance(systemConfig);
             }
 
             if (obj instanceof EmbulkService) {


### PR DESCRIPTION
Can you check my fix? I still get another error like:

```
2015-06-30 17:20:18,266 INFO [AsyncDispatcher event handler] org.apache.hadoop.mapreduce.v2.app.job.impl.TaskAttemptImpl: Diagnostics report from attempt_1435573321384_0725_m_000002_0: Error: java.lang.IllegalArgumentException: argument type mismatch
    at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
    at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:57)
    at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
    at java.lang.reflect.Constructor.newInstance(Constructor.java:526)
    at org.embulk.executor.mapreduce.EmbulkMapReduce.newEmbulkInstance(EmbulkMapReduce.java:121)
    at org.embulk.executor.mapreduce.EmbulkMapReduce$SessionRunner.<init>(EmbulkMapReduce.java:248)
    at org.embulk.executor.mapreduce.EmbulkPartitioningMapReduce$EmbulkPartitioningMapper.setup(EmbulkPartitioningMapReduce.java:51)
    at org.apache.hadoop.mapreduce.Mapper.run(Mapper.java:142)
    at org.apache.hadoop.mapred.MapTask.runNewMapper(MapTask.java:764)
    at org.apache.hadoop.mapred.MapTask.run(MapTask.java:340)
    at org.apache.hadoop.mapred.YarnChild$2.run(YarnChild.java:168)
    at java.security.AccessController.doPrivileged(Native Method)
    at javax.security.auth.Subject.doAs(Subject.java:415)
    at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1594)
    at org.apache.hadoop.mapred.YarnChild.main(YarnChild.java:163)
```
