### PR TITLE
Consider retrying of attempts and jobs

### DIFF
--- a/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/EmbulkMapReduce.java
+++ b/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/EmbulkMapReduce.java
@@ -167,7 +167,7 @@ public class EmbulkMapReduce
 
     public static JobStatus getJobStatus(final Job job) throws IOException
     {
-        return fragileHadoopOperation("getting job status", new Callable<JobStatus>() {
+        return hadoopOperationWithRetry("getting job status", new Callable<JobStatus>() {
             public JobStatus call() throws IOException
             {
                 return new JobStatus(job.isComplete(), job.mapProgress(), job.reduceProgress());
@@ -177,7 +177,7 @@ public class EmbulkMapReduce
 
     public static Counters getJobCounters(final Job job) throws IOException
     {
-        return fragileHadoopOperation("getting job counters", new Callable<Counters>() {
+        return hadoopOperationWithRetry("getting job counters", new Callable<Counters>() {
             public Counters call() throws IOException
             {
                 return job.getCounters();
@@ -188,7 +188,7 @@ public class EmbulkMapReduce
     public static List<TaskAttemptID> listAttempts(final Configuration config,
             final Path stateDir) throws IOException
     {
-        return fragileHadoopOperation("getting list of attempt state files on "+stateDir, new Callable<List<TaskAttemptID>>() {
+        return hadoopOperationWithRetry("getting list of attempt state files on "+stateDir, new Callable<List<TaskAttemptID>>() {
             public List<TaskAttemptID> call() throws IOException
             {
                 FileStatus[] stats = stateDir.getFileSystem(config).listStatus(stateDir);
@@ -215,7 +215,7 @@ public class EmbulkMapReduce
             final PluginArchive archive, final ModelManager modelManager) throws IOException
     {
         final Path path = new Path(stateDir, PLUGIN_ARCHIVE_FILE_NAME);
-        fragileHadoopOperation("writing plugin archive to "+path, new Callable<Void>() {
+        hadoopOperationWithRetry("writing plugin archive to "+path, new Callable<Void>() {
             public Void call() throws IOException
             {
                 stateDir.getFileSystem(config).mkdirs(stateDir);
@@ -232,7 +232,7 @@ public class EmbulkMapReduce
             Path stateDir, final ModelManager modelManager) throws IOException
     {
         final Path path = new Path(stateDir, PLUGIN_ARCHIVE_FILE_NAME);
-        return fragileHadoopOperation("reading plugin archive file from "+path, new Callable<PluginArchive>() {
+        return hadoopOperationWithRetry("reading plugin archive file from "+path, new Callable<PluginArchive>() {
                 public PluginArchive call() throws IOException
                 {
                     List<PluginArchive.GemSpec> specs = modelManager.readObject(
@@ -249,7 +249,7 @@ public class EmbulkMapReduce
             Path stateDir, final AttemptState state, final ModelManager modelManager) throws IOException
     {
         final Path path = new Path(stateDir, state.getAttemptId().toString());
-        fragileHadoopOperation("writing attempt state file to "+path, new Callable<Void>() {
+        hadoopOperationWithRetry("writing attempt state file to "+path, new Callable<Void>() {
             public Void call() throws IOException
             {
                 try (FSDataOutputStream out = path.getFileSystem(config).create(path, true)) {
@@ -322,7 +322,7 @@ public class EmbulkMapReduce
         }
     }
 
-    private static <T> T fragileHadoopOperation(final String message, final Callable<T> callable) throws IOException
+    private static <T> T hadoopOperationWithRetry(final String message, final Callable<T> callable) throws IOException
     {
         final Logger log = Exec.getLogger(EmbulkMapReduce.class);
         try {

--- a/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/MapReduceExecutor.java
+++ b/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/MapReduceExecutor.java
@@ -167,9 +167,11 @@ public class MapReduceExecutor
                 return true;
             }
 
-            // TaskAttemptID.compareTo returns unexpected result if 2 jobs run on different JobTrackers
-            // because JobID includes start time of a JobTracker rather than start time of a job.
-            // To mitigate this problem, this code assumes the running job is always the latest.
+            // Here expects that TaskAttemptID.compareTo returns <= 0 if attempt is started later.
+            // However, it returns unexpected result if 2 jobs run on different JobTrackers because
+            // JobID includes start time of a JobTracker with sequence number in the JobTracker
+            // rather than start time of a job. To mitigate this problem, this code assumes that
+            // attempts of the running job is always newer.
             boolean pastRunning = past.getTaskAttempId().getJobID().equals(runningJobId);
             boolean reportRunning = report.getTaskAttempId().getJobID().equals(runningJobId);
             if (!pastRunning && reportRunning) {
@@ -452,8 +454,6 @@ public class MapReduceExecutor
             return attemptState;
         }
     }
-
-    private static final int TASK_EVENT_FETCH_SIZE = 100;
 
     private static List<AttemptReport> getAttemptReports(Configuration config,
             Path stateDir, ModelManager modelManager,


### PR DESCRIPTION
A job might be retried with the same unique name (return value of
MapReduceExecutor.getTransactionUniqueName). An attempt of the same task
also might be retired. In this case, stateDir contains multiple
AttemptState files for the same input/output task index.

This pull-request solves this problem using this algorithm:
- Ignore AttemptState files created by past attempts if there is
  already newer AttemptState for the same input/output task.
  (implemented at MapReduceExecutor.TaskReportSet.update)
- Even if AttemptState files are broken, updateProcessState() ignores
  them them because those files could be a garbage created by past
  attempts. It throws an exception onlly if HDFS is broken for sure.
- updateProcessState() method confirms that HDFS is broken for sure
  using following logic:
  - EOFException means HDFS is working. Ignore it.
  - If job is already finished, "Cannot obtain block length for
    LocatedBlock" exception (HDFS-1058) should never happen.
    In this case, IOException means HDFS is broken. throw it.
