### PR TITLE
Kills job on job or interrupt

### DIFF
--- a/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/EmbulkMapReduce.java
+++ b/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/EmbulkMapReduce.java
@@ -167,6 +167,17 @@ public class EmbulkMapReduce
         }
     }
 
+    public static void killJob(final Job job) throws IOException
+    {
+        hadoopOperationWithRetry("killing job", new Callable<Void>() {
+            public Void call() throws IOException
+            {
+                job.killJob();
+                return null;
+            }
+        });
+    }
+
     public static JobStatus getJobStatus(final Job job) throws IOException
     {
         return hadoopOperationWithRetry("getting job status", new Callable<JobStatus>() {


### PR DESCRIPTION
When the main thread throws an exception (especially when it access to HDFS)
or a process is killed, running job is kept on YARN. This change fixes
this issue by killing it at finally block.
