### PR TITLE
Add sourceCompatibility and targetCompatibility to build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,9 @@ subprojects {
         jcenter()
     }
 
+    sourceCompatibility = 1.7
+    targetCompatibility = 1.7
+
     configurations {
         provided
         // exclude xercesImpl and xml-apis jars that causes a problem with javax.xml.parsers.DocumentBuilderFactory.


### PR DESCRIPTION
It's better to declare same java version as Embulk itself.
https://github.com/embulk/embulk/blob/master/build.gradle#L91-L92
