### PR TITLE
Add exclude_jar option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This executor plugin can partition data by a column before passing records to ou
     - **unit** "hour" or "day" (enum, required)
     - **timezone: UTC** only "UTC" is supported for now. (string, optional)
     - **unix_timestamp_unit** unit of the unix timestamp if type of the column is long. "sec", "milli" (for milliseconds), "micro" (for micorseconds), or "nano" (for nanoseconds). (enum, default: `"sec"`)
+- **exclude_jars**: glob pattern to exclude jar files. e.g. `[log4j-over-slf4j.jar, log4j-core-*]` (array of strings, default: `[]`)
 
 
 ### Partitioning

--- a/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/MapReduceExecutorTask.java
+++ b/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/MapReduceExecutorTask.java
@@ -31,6 +31,10 @@ public interface MapReduceExecutorTask
     @ConfigDefault("[]")
     public List<String> getLibjars();
 
+    @Config("exclude_jars")
+    @ConfigDefault("[]")
+    public List<String> getExcludeJars();
+
     @Config("state_path")
     @ConfigDefault("\"/tmp/embulk\"")
     public String getStatePath();


### PR DESCRIPTION
This option is necessary to let users exclude dependent jar files that
conflict with Hadoop's dependent jars. For example, log4j-over-slf4j.jar
(in plugins) conflicts with slf4j-log4j12.jar (in hadoop).
