### PR TITLE
Remote MapReduce Tasks propagate UserDataException

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,8 +34,8 @@ subprojects {
     }
 
     dependencies {
-        compile  'org.embulk:embulk-core:0.7.5'
-        provided 'org.embulk:embulk-core:0.7.5'
+        compile  'org.embulk:embulk-core:0.7.6'
+        provided 'org.embulk:embulk-core:0.7.6'
         compile 'org.apache.hadoop:hadoop-client:2.6.0'
         testCompile 'junit:junit:4.+'
     }

--- a/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/AttemptState.java
+++ b/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/AttemptState.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import org.apache.hadoop.mapreduce.TaskAttemptID;
 import org.embulk.config.ModelManager;
 import org.embulk.config.TaskReport;
+import org.embulk.config.UserDataExceptions;
 
 public class AttemptState
 {
@@ -24,6 +25,7 @@ public class AttemptState
     private final Optional<Integer> inputTaskIndex;
     private final Optional<Integer> outputTaskIndex;
     private Optional<String> exception;
+    private boolean userDataException;
     private Optional<TaskReport> inputTaskReport;
     private Optional<TaskReport> outputTaskReport;
 
@@ -40,11 +42,13 @@ public class AttemptState
             @JsonProperty("inputTaskIndex") Optional<Integer> inputTaskIndex,
             @JsonProperty("outputTaskIndex") Optional<Integer> outputTaskIndex,
             @JsonProperty("exception") Optional<String> exception,
+            @JsonProperty("userDataException") boolean userDataException,
             @JsonProperty("inputTaskReport") Optional<TaskReport> inputTaskReport,
             @JsonProperty("outputTaskReport") Optional<TaskReport> outputTaskReport)
     {
         this(TaskAttemptID.forName(attemptId),
-                inputTaskIndex, outputTaskIndex, exception,
+                inputTaskIndex, outputTaskIndex,
+                exception, userDataException,
                 inputTaskReport, outputTaskReport);
     }
 
@@ -53,6 +57,7 @@ public class AttemptState
             Optional<Integer> inputTaskIndex,
             Optional<Integer> outputTaskIndex,
             Optional<String> exception,
+            boolean userDataException,
             Optional<TaskReport> inputTaskReport,
             Optional<TaskReport> outputTaskReport)
     {
@@ -60,6 +65,7 @@ public class AttemptState
         this.inputTaskIndex = inputTaskIndex;
         this.outputTaskIndex = outputTaskIndex;
         this.exception = exception;
+        this.userDataException = userDataException;
         this.inputTaskReport = inputTaskReport;
         this.outputTaskReport = outputTaskReport;
     }
@@ -97,19 +103,28 @@ public class AttemptState
         } catch (UnsupportedEncodingException ex) {
             throw new RuntimeException(ex);
         }
-        setException(new String(os.toByteArray(), StandardCharsets.UTF_8));
+        setException(
+                new String(os.toByteArray(), StandardCharsets.UTF_8),
+                UserDataExceptions.isUserDataException(exception));
     }
 
     @JsonIgnore
-    public void setException(String exception)
+    public void setException(String exception, boolean userDataException)
     {
         this.exception = Optional.of(exception);
+        this.userDataException = userDataException;
     }
 
     @JsonProperty("exception")
     public Optional<String> getException()
     {
         return exception;
+    }
+
+    @JsonProperty("userDataException")
+    public boolean isUserDataException()
+    {
+        return userDataException;
     }
 
     @JsonProperty("inputTaskReport")

--- a/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/MapReduceExecutor.java
+++ b/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/MapReduceExecutor.java
@@ -409,7 +409,13 @@ public class MapReduceExecutor
         boolean committed = taskReport.isPresent();
         if (attempt.getException().isPresent()) {
             if (!state.isCommitted()) {
-                state.setException(new RemoteTaskFailedException(attempt.getException().get()));
+                Exception remoteException;
+                if (attempt.isUserDataException()) {
+                    remoteException = new RemoteTaskFailedDataException(attempt.getException().get());
+                } else {
+                    remoteException = new RemoteTaskFailedException(attempt.getException().get());
+                }
+                state.setException(remoteException);
             }
         }
         if (taskReport.isPresent()) {

--- a/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/RemoteTaskFailedDataException.java
+++ b/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/RemoteTaskFailedDataException.java
@@ -1,0 +1,12 @@
+package org.embulk.executor.mapreduce;
+
+import org.embulk.spi.DataException;
+
+public class RemoteTaskFailedDataException
+        extends DataException
+{
+    public RemoteTaskFailedDataException(String message)
+    {
+        super(message);
+    }
+}


### PR DESCRIPTION
When a task fails with UserDataException or its subclass, it should be
propagated to main thread so that
`UserDataExceptions.isUserDataException(partialExecutionException)`
returns true. This is necessary for applications to tell whether this
failure is worth to retry or not until input data is fixed.
