### PR TITLE
Add retry_tasks option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ This executor plugin can partition data by a column before passing records to ou
 - **config** overwrites configuration parameters (hash, default: `{}`)
 - **job_name** name of the job (string, default: `"embulk"`)
 - **reducers** number of reduce tasks. This parameter is used only when `partitioning` parameter is set (integer, default: same number with input tasks)
+- **retry_tasks** retries failed tasks automatically (boolean, default: `false`)
+    - when partitioning is not used: if retry_tasks is true, map tasks are retried at most `mapreduce.map.maxattempts` times (default is 4). Reduce tasks don't run.
+    - when partitioning is used: if retry_tasks is true, reduce tasks are retried at most `mapreduce.reduce.maxattempts` times (default is 4). Mapper tasks are retried regardless of this option.
 - **libjars** additional jar files to run this MapReduce application (array of strings, default: `[]`)
 - **state_path** path to a directory on the default filesystem (usually HDFS) to store temporary progress report files (string, default: `"/tmp/embulk"`)
 - **partitioning** partitioning strategy. see below (hash, default: no partitioning)

--- a/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/MapReduceExecutor.java
+++ b/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/MapReduceExecutor.java
@@ -223,6 +223,7 @@ public class MapReduceExecutor
         EmbulkMapReduce.setSystemConfig(conf, modelManager, systemConfig);
         EmbulkMapReduce.setExecutorTask(conf, modelManager, task);
         EmbulkMapReduce.setMapTaskCount(conf, mapTaskCount);  // used by EmbulkInputFormat
+        EmbulkMapReduce.setRetryTasks(conf, task.getRetryTasks());
         EmbulkMapReduce.setStateDirectoryPath(conf, stateDir);
 
         // jar files

--- a/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/MapReduceExecutorTask.java
+++ b/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/MapReduceExecutorTask.java
@@ -43,6 +43,10 @@ public interface MapReduceExecutorTask
     @ConfigDefault("null")
     public Optional<Integer> getReducers();
 
+    @Config("retry_tasks")
+    @ConfigDefault("false")
+    public boolean getRetryTasks();
+
     @Config("partitioning")
     @ConfigDefault("null")
     public Optional<ConfigSource> getPartitioning();


### PR DESCRIPTION
This option is useful when output plugin is retryable but not resumable.
This option is disabled by default because not all output plugins are
retryable.
