### PR TITLE
Add map_side_partition_split option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This executor plugin can partition data by a column before passing records to ou
     - **unit** "hour" or "day" (enum, required)
     - **timezone: UTC** only "UTC" is supported for now. (string, optional)
     - **unix_timestamp_unit** unit of the unix timestamp if type of the column is long. "sec", "milli" (for milliseconds), "micro" (for micorseconds), or "nano" (for nanoseconds). (enum, default: `"sec"`)
+    - **map_side_partition_split** distributes one partition into multiple reducers. This option is helpful when only a few reducers out of many reducers take long time. This splits one partition into smaller chunks. (integer, default: `1`)
 - **exclude_jars**: glob pattern to exclude jar files. e.g. `[log4j-over-slf4j.jar, log4j-core-*]` (array of strings, default: `[]`)
 
 

--- a/embulk-executor-mapreduce/src/test/java/org/embulk/executor/mapreduce/TestTimestampPartitioning.java
+++ b/embulk-executor-mapreduce/src/test/java/org/embulk/executor/mapreduce/TestTimestampPartitioning.java
@@ -117,7 +117,7 @@ public class TestTimestampPartitioning
         Column c1 = new Column(1, "c1", Types.TIMESTAMP);
         Schema schema = new Schema(Arrays.asList(c0, c1));
 
-        LongUnixTimestampPartitioner lp = new LongUnixTimestampPartitioner(c0, Unit.HOUR, UnixTimestampUnit.SEC);
+        LongUnixTimestampPartitioner lp = new LongUnixTimestampPartitioner(c0, Unit.HOUR, 1, UnixTimestampUnit.SEC);
         TimestampPartitioner tp = new TimestampPartitioner(c1, Unit.HOUR);
 
         long timeWindow = System.currentTimeMillis()/1000/3600*3600;


### PR DESCRIPTION
When input data is within small time range, a few reducers take long
time. For example, if input data is within 2-hour range and unit is
hour, only 2 reducers work, although the other reducers finish
immediately.

map_side_partition_split option solves it by splitting one partition
into smaller chunk by a static number at mapper stage.

follows-up #29.
