### PR TITLE
Add local_mode_input_tasks option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This executor plugin can partition data by a column before passing records to ou
     - **unix_timestamp_unit** unit of the unix timestamp if type of the column is long. "sec", "milli" (for milliseconds), "micro" (for micorseconds), or "nano" (for nanoseconds). (enum, default: `"sec"`)
     - **map_side_partition_split** distributes one partition into multiple reducers. This option is helpful when only a few reducers out of many reducers take long time. This splits one partition into smaller chunks. (integer, default: `1`)
 - **exclude_jars**: glob pattern to exclude jar files. e.g. `[log4j-over-slf4j.jar, log4j-core-*]` (array of strings, default: `[]`)
+- **local_mode_input_tasks**: executes input tasks on local if the task count is equal or less than this parameter (integer, default: 0)
 
 
 ### Partitioning

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This executor plugin can partition data by a column before passing records to ou
     - **unix_timestamp_unit** unit of the unix timestamp if type of the column is long. "sec", "milli" (for milliseconds), "micro" (for micorseconds), or "nano" (for nanoseconds). (enum, default: `"sec"`)
     - **map_side_partition_split** distributes one partition into multiple reducers. This option is helpful when only a few reducers out of many reducers take long time. This splits one partition into smaller chunks. (integer, default: `1`)
 - **exclude_jars**: glob pattern to exclude jar files. e.g. `[log4j-over-slf4j.jar, log4j-core-*]` (array of strings, default: `[]`)
-- **local_mode_input_tasks**: executes input tasks on local if the task count is equal or less than this parameter (integer, default: 0)
+- **local_mode_input_tasks**: executes tasks using local threads instead of distributed MapReduce if number of input tasks is equal or less than this parameter (integer, default: 0). Setting this to 1 or 2 is useful to improve performance because starting a MapReduce job can take longer time than running a small transaction. Note: `partitioning` option is local mode is enabled. This will be fixed in a future release by implementing pseudo MapReduce execution that performs partitioning using local threads.
 
 
 ### Partitioning

--- a/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/MapReduceExecutorTask.java
+++ b/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/MapReduceExecutorTask.java
@@ -12,6 +12,8 @@ import org.embulk.config.TaskSource;
 import org.embulk.config.ModelManager;
 import org.embulk.spi.ProcessTask;
 
+import javax.validation.constraints.Min;
+
 public interface MapReduceExecutorTask
         extends Task
 {
@@ -50,6 +52,11 @@ public interface MapReduceExecutorTask
     @Config("partitioning")
     @ConfigDefault("null")
     public Optional<ConfigSource> getPartitioning();
+
+    @Config("local_mode_input_tasks")
+    @ConfigDefault("0")
+    @Min(0)
+    public Integer getLocalModeInputTasks();
 
     @ConfigInject
     public ModelManager getModelManager();


### PR DESCRIPTION
Input task count is equal or smaller than the option value, input tasks are executed by local executor. This mode would be useful in the case that the # of input tasks is 1 or 2. Because they might finish by local executor in the meantime while MR applications are bootstrapped. 

Default value is 0. It means that mapreduce executor submits MR jobs by default.
