### PR TITLE
experimental support of task logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ subprojects {
         compile  'org.embulk:embulk-core:0.8.9'
         provided 'org.embulk:embulk-core:0.8.9'
         compile 'org.apache.hadoop:hadoop-client:2.6.0'
+        compile 'net.jpountz.lz4:lz4:1.3.0'
 
         testCompile 'junit:junit:4.+'
         testCompile 'org.embulk:embulk-core:0.8.9:tests'

--- a/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/FileSystemAttemptLogAppender.java
+++ b/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/FileSystemAttemptLogAppender.java
@@ -1,0 +1,90 @@
+package org.embulk.executor.mapreduce;
+
+import java.io.OutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import net.jpountz.lz4.LZ4Compressor;
+import net.jpountz.lz4.LZ4Factory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.Path;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Throwables;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class FileSystemAttemptLogAppender
+    implements ThreadLocalLogger
+{
+    private static final Logger systemLogger = LoggerFactory.getLogger(FileSystemAttemptLogAppender.class);
+
+    public static FileSystemAttemptLogAppender openIfSupported(Configuration config, Path path, boolean run)
+        throws IOException
+    {
+        FSDataOutputStream out;
+        try {
+            out = path.getFileSystem(config).append(path);
+        }
+        catch (IOException ex) {
+            if (ex.getMessage().contains("Not supported")) {
+                if (run) {
+                    // ballback to create
+                    out = path.getFileSystem(config).create(path);
+                }
+                else {
+                    // show also to stderr because logger is likely broken
+                    systemLogger.error("FileSystem doesn't support append mode.");
+                    System.err.println("FileSystem doesn't support append mode.");
+                    return null;
+                }
+            }
+            else {
+                throw ex;
+            }
+        }
+        return new FileSystemAttemptLogAppender(out);
+    }
+
+    private final LZ4Compressor compressor = LZ4Factory.fastestInstance().highCompressor();
+    private final OutputStream out;
+    private final ObjectMapper mapper = new ObjectMapper();
+    private ByteBuffer buffer = ByteBuffer.wrap(new byte[32*1024]);
+
+    public FileSystemAttemptLogAppender(OutputStream out)
+    {
+        this.out = out;
+    }
+
+    @Override
+    public synchronized void log(LogMessage message)
+    {
+        try {
+            byte[] data = mapper.writeValueAsBytes(message);
+            int maxPossibleSize = 4 + compressor.maxCompressedLength(data.length);  // 4 for bytes header
+
+            if (buffer.capacity() < maxPossibleSize) {
+                int allocSize = buffer.capacity();
+                do {
+                    allocSize *= 2;
+                } while (allocSize < maxPossibleSize);
+                buffer = ByteBuffer.wrap(new byte[allocSize]);
+            }
+
+            int len = compressor.compress(data, 0, data.length, buffer.array(), 4);
+            buffer.putInt(0, len);
+
+            out.write(buffer.array(), 0, 4 + len);
+        }
+        catch (IOException ex) {
+            throw Throwables.propagate(ex);
+        }
+    }
+
+    public void close()
+        throws IOException
+    {
+        out.close();
+    }
+}

--- a/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/LogMessage.java
+++ b/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/LogMessage.java
@@ -1,0 +1,100 @@
+package org.embulk.executor.mapreduce;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public class LogMessage
+{
+    public static enum Level
+    {
+        ERROR("error"),
+        WARN("warn"),
+        INFO("info"),
+        DEBUG("debug"),
+        TRACE("trace");
+
+        private final String name;
+
+        private Level(String name)
+        {
+            this.name = name;
+        }
+
+        @JsonCreator
+        public static Level of(String name)
+        {
+            switch (name) {
+            case "error":
+                return ERROR;
+            case "warn":
+                return WARN;
+            case "info":
+                return INFO;
+            case "debug":
+                return DEBUG;
+            case "trace":
+                return TRACE;
+            default:
+                throw new IllegalArgumentException("Unknown log level: " + name);
+            }
+        }
+
+        @JsonValue
+        public String toString()
+        {
+            return name;
+        }
+    }
+
+    private final long timestamp;
+    private final Level level;
+    private final String loggerName;
+    private final String threadName;
+    private final String message;
+
+    @JsonCreator
+    public LogMessage(
+            @JsonProperty("timestamp") long timestamp,
+            @JsonProperty("level") Level level,
+            @JsonProperty("logger") String loggerName,
+            @JsonProperty("thread") String threadName,
+            @JsonProperty("message") String message)
+    {
+        this.timestamp = timestamp;
+        this.level = level;
+        this.loggerName = loggerName;
+        this.threadName = threadName;
+        this.message = message;
+    }
+
+    @JsonProperty("timestamp")
+    public long getTimestamp()
+    {
+        return timestamp;
+    }
+
+    @JsonProperty("level")
+    public Level getLevel()
+    {
+        return level;
+    }
+
+    @JsonProperty("logger")
+    public String getLoggerName()
+    {
+        return loggerName;
+    }
+
+    @JsonProperty("thread")
+    public String getThreadName()
+    {
+        return threadName;
+    }
+
+    @JsonProperty("message")
+    public String getMessage()
+    {
+        return message;
+    }
+}

--- a/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/LogWatcher.java
+++ b/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/LogWatcher.java
@@ -1,0 +1,170 @@
+package org.embulk.executor.mapreduce;
+
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+import java.io.IOException;
+import net.jpountz.lz4.LZ4SafeDecompressor;
+import net.jpountz.lz4.LZ4Factory;
+import net.jpountz.lz4.LZ4Exception;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.mapreduce.TaskAttemptID;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import static org.embulk.executor.mapreduce.EmbulkMapReduce.listLogFiles;
+
+public class LogWatcher
+{
+    private final Logger logger = LoggerFactory.getLogger(LogWatcher.class);
+
+    private static class LastState
+    {
+        private int failCount = 0;
+        private long offset = 0;
+        private long lastSize = 0;
+
+        public boolean isReadable()
+        {
+            return failCount < 10;
+        }
+
+        public boolean isGrown(long newSize)
+        {
+            return lastSize < newSize;
+        }
+
+        public long getOffset()
+        {
+            return offset;
+        }
+
+        public void update(long offset, long newSize)
+        {
+            this.offset = offset;
+            this.lastSize = newSize;
+        }
+
+        public void fail()
+        {
+            failCount++;
+        }
+    }
+
+    private final Configuration config;
+    private final Path stateDir;
+    private final Map<TaskAttemptID, LastState> files = new HashMap<>();
+
+    private byte[] readBuffer = new byte[32*1024];
+    private final byte[] decompBuffer = new byte[64*1024];
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private final LZ4SafeDecompressor decompressor = LZ4Factory.fastestInstance().safeDecompressor();
+
+    public LogWatcher(Configuration config, Path stateDir)
+    {
+        this.config = config;
+        this.stateDir = stateDir;
+    }
+
+    public void update()
+        throws IOException
+    {
+        for (Map.Entry<TaskAttemptID, FileStatus> pair : listLogFiles(config, stateDir).entrySet()) {
+            LastState lastState = files.get(pair.getKey());
+            if (lastState == null) {
+                lastState = new LastState();
+                files.put(pair.getKey(), lastState);
+            }
+            else if (!lastState.isReadable()) {
+                continue;
+            }
+
+            long newSize = pair.getValue().getLen();
+            if (lastState.isGrown(newSize)) {
+                try {
+                    long newOffset = showMoreLogs(pair.getValue().getPath(), lastState.getOffset(), newSize);
+                    lastState.update(newOffset, newSize);
+                }
+                catch (Exception ex) {
+                    ex.printStackTrace();
+                    logger.warn("Failed to read log file " + pair.getValue().getPath(), ex);
+                    lastState.fail();
+                }
+            }
+        }
+    }
+
+    private long showMoreLogs(Path path, long offset, long fileSize)
+        throws IOException
+    {
+        FSDataInputStream in = path.getFileSystem(config).open(path);
+        in.seek(offset);
+        while (true) {
+            if (fileSize < offset + 4) {
+                return offset;
+            }
+            int n = in.readInt();
+            if (fileSize < offset + 4 + n) {
+                return offset;
+            }
+
+            if (readBuffer.length < n) {
+                int allocSize = readBuffer.length;
+                do {
+                    allocSize *= 2;
+                } while (allocSize < n);
+                readBuffer = new byte[allocSize];
+            }
+            in.readFully(readBuffer, 0, n);
+
+            try {
+                int dec = decompressor.decompress(readBuffer, 0, n, decompBuffer, 0);
+                LogMessage message = mapper.readValue(decompBuffer, 0, dec, LogMessage.class);
+                logMessage(message);
+            }
+            catch (LZ4Exception ex) {
+                ex.printStackTrace();
+                logger.warn("Skipping too long log message");
+            }
+
+            offset += 4 + n;
+        }
+    }
+
+    private String lastLoggerName = "";
+    private Logger lastLogger = LoggerFactory.getLogger(lastLoggerName);
+
+    private void logMessage(LogMessage message)
+    {
+        Thread currentThread = Thread.currentThread();
+        String savedThreadName = currentThread.getName();
+        try {
+            currentThread.setName(message.getThreadName());
+            String loggerName = message.getLoggerName();
+            if (!lastLoggerName.equals(loggerName)) {
+                lastLogger = LoggerFactory.getLogger(loggerName);
+                lastLoggerName = loggerName;
+            }
+            switch (message.getLevel()) {
+            case TRACE:
+                lastLogger.trace(message.getMessage());
+            case DEBUG:
+                lastLogger.debug(message.getMessage());
+            case INFO:
+                lastLogger.info(message.getMessage());
+            case WARN:
+                lastLogger.warn(message.getMessage());
+            case ERROR:
+                lastLogger.error(message.getMessage());
+            }
+        }
+        finally {
+            currentThread.setName(savedThreadName);
+        }
+    }
+}

--- a/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/LogbackThreadLocalLoggerAdapter.java
+++ b/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/LogbackThreadLocalLoggerAdapter.java
@@ -1,0 +1,59 @@
+package org.embulk.executor.mapreduce;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.UnsynchronizedAppenderBase;
+import ch.qos.logback.classic.Level;
+import static ch.qos.logback.classic.Level.ERROR_INT;
+import static ch.qos.logback.classic.Level.WARN_INT;
+import static ch.qos.logback.classic.Level.INFO_INT;
+import static ch.qos.logback.classic.Level.DEBUG_INT;
+import static ch.qos.logback.classic.Level.TRACE_INT;
+
+public class LogbackThreadLocalLoggerAdapter
+    extends UnsynchronizedAppenderBase<ILoggingEvent>
+{
+    @Override
+    public void start()
+    {
+        if (isStarted()) {
+            return;
+        }
+
+        super.start();
+    }
+
+    @Override
+    protected void append(ILoggingEvent event)
+    {
+        ThreadLocalLogger threadLocal = ThreadLocalLogger.instance.get();
+        if (threadLocal != null) {
+            LogMessage message = new LogMessage(
+                    event.getTimeStamp(),
+                    logLevel(event.getLevel()),
+                    event.getLoggerName(),
+                    event.getThreadName(),
+                    event.getFormattedMessage());
+            threadLocal.log(message);
+        }
+    }
+
+    private static LogMessage.Level logLevel(Level level)
+    {
+        int lv = level.toInt();
+        if (lv >= ERROR_INT) {
+            return LogMessage.Level.ERROR;
+        }
+        else if (lv >= WARN_INT) {
+            return LogMessage.Level.WARN;
+        }
+        else if (lv >= INFO_INT) {
+            return LogMessage.Level.INFO;
+        }
+        else if (lv >= DEBUG_INT) {
+            return LogMessage.Level.DEBUG;
+        }
+        else {
+            return LogMessage.Level.TRACE;
+        }
+    }
+}

--- a/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/ThreadLocalLogger.java
+++ b/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/ThreadLocalLogger.java
@@ -1,0 +1,8 @@
+package org.embulk.executor.mapreduce;
+
+public interface ThreadLocalLogger
+{
+    public static final InheritableThreadLocal<ThreadLocalLogger> instance = new InheritableThreadLocal<ThreadLocalLogger>();
+
+	void log(LogMessage message);
+}


### PR DESCRIPTION
This is an experimental implementation of task logging.

This is expected to work as following:
1. master process creates a log directory on `<state_path>/<uniqueTransactionName>/logs` (this is supposed to be HDFS).
2. mapper and reducers hook slf4j logger (this is a big hack) into a custom appender (`LogbackThreadLocalLoggerAdapter`).
3. the custom append passes logs to a thread-local object (`ThreadLocalLogger.instance`). This is necessary because sl4j loggers are jvm-global singleton.
4. mapper and reducer processes set `FileSystemAttemptLogAppender` to the thread-local object.
5. `FileSystemAttemptLogAppender` appends logs to `<state_path>/<uniqueTransactionName>/logs/<attemptId>`
6. master process watches the logs directly periodically. If a file grows, reads the grown part and passes them to a slf4j logger (this slf4j logger is master process's logger).

Log file format is JSON-with-size-header.

```
<size-in-4-byte-int><lz4-compressed-json>
<size-in-4-byte-int><lz4-compressed-json>
<size-in-4-byte-int><lz4-compressed-json>
...
```

`<lz4-compressed-json>` contains a log message as a JSON format with "timestamp", "level", "logger", "thread", and "message" fields.

Here uses size header over json-per-line because offset calculation becomes much simpler. It also makes it unecessary to handle partially-written multibyte characters.

When master process passes the JSON a slf4j logger, it fakes loggerName and threadName so that the master process's logger can format message with appropriate loggerName and threadName.

Master process checks log file every `org.apache.hadoop.mapreduce.Job.getCompletionPollInterval` milliseconds. This is usually 5 seconds.

Task logging doesn't work with local-mode mapreduce at all. It's because slf4j (and logback) is a process-global singleton. Once mapper or reducer tasks hook the logger, master process can't log any more.
