### PR TITLE
Fix for Embulk 0.8.24 on 'new PluginType("local")'.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,3 @@
-
 plugins {
     id 'com.jfrog.bintray' version '1.1'
     id 'com.github.jruby-gradle.base' version '0.1.5'
@@ -43,13 +42,13 @@ subprojects {
     }
 
     dependencies {
-        compile  'org.embulk:embulk-core:0.8.9'
-        provided 'org.embulk:embulk-core:0.8.9'
+        compile  'org.embulk:embulk-core:0.8.25'
+        provided 'org.embulk:embulk-core:0.8.25'
         compile 'org.apache.hadoop:hadoop-client:2.6.0'
 
         testCompile 'junit:junit:4.+'
-        testCompile 'org.embulk:embulk-core:0.8.9:tests'
-        testCompile 'org.embulk:embulk-standards:0.8.9'
+        testCompile 'org.embulk:embulk-core:0.8.25:tests'
+        testCompile 'org.embulk:embulk-standards:0.8.25'
         testRuntime 'org.embulk.executor.mapreduce:embulk-executor-mapreduce'
     }
 

--- a/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/MapReduceExecutor.java
+++ b/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/MapReduceExecutor.java
@@ -84,7 +84,7 @@ public class MapReduceExecutor
             // if task count is equal or less than local_mode_input_tasks option, those tasks are executed by local executor
             // TODO if partitioning config is present, they are executed by hadoop local mode
             log.info("Executing tasks on using local threads");
-            ExecutorPlugin local = Exec.newPlugin(ExecutorPlugin.class, new PluginType("local"));
+            ExecutorPlugin local = Exec.newPlugin(ExecutorPlugin.class, PluginType.LOCAL);
             local.transaction(config, outputSchema, inputTaskCount, control);
             return;
         }


### PR DESCRIPTION
@muga Hmm, this is an unexpected breakage caused by: https://github.com/embulk/embulk/pull/666

This PR is a quick fix, but we may want another better fix (maybe on Embulk's side). What do you think?