### PR TITLE
Add embulk-executor-mapreduce_2_7.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,6 @@ subprojects {
     dependencies {
         compile  'org.embulk:embulk-core:0.8.25'
         provided 'org.embulk:embulk-core:0.8.25'
-        compile 'org.apache.hadoop:hadoop-client:2.6.0'
 
         testCompile 'junit:junit:4.+'
         testCompile 'org.embulk:embulk-core:0.8.25:tests'

--- a/embulk-executor-mapreduce/build.gradle
+++ b/embulk-executor-mapreduce/build.gradle
@@ -1,2 +1,3 @@
 dependencies {
+    compile 'org.apache.hadoop:hadoop-client:2.6.0'
 }

--- a/embulk-executor-mapreduce_2_7/build.gradle
+++ b/embulk-executor-mapreduce_2_7/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    compile 'org.apache.hadoop:hadoop-client:2.7.3'
+}

--- a/embulk-executor-mapreduce_2_7/lib/embulk/executor/mapreduce.rb
+++ b/embulk-executor-mapreduce_2_7/lib/embulk/executor/mapreduce.rb
@@ -1,0 +1,3 @@
+Embulk::JavaPlugin.register_executor(
+  :mapreduce, "org.embulk.executor.mapreduce.MapReduceExecutor",
+  File.expand_path('../../../../classpath', __FILE__))

--- a/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/AttemptState.java
+++ b/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/AttemptState.java
@@ -1,0 +1,170 @@
+package org.embulk.executor.mapreduce;
+
+import java.util.Scanner;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.IOException;
+import java.io.EOFException;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import com.google.common.base.Optional;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.apache.hadoop.mapreduce.TaskAttemptID;
+import org.embulk.config.ModelManager;
+import org.embulk.config.TaskReport;
+import org.embulk.config.UserDataExceptions;
+
+public class AttemptState
+{
+    private final TaskAttemptID attemptId;
+    private final Optional<Integer> inputTaskIndex;
+    private final Optional<Integer> outputTaskIndex;
+    private Optional<String> exception;
+    private boolean userDataException;
+    private Optional<TaskReport> inputTaskReport;
+    private Optional<TaskReport> outputTaskReport;
+
+    public AttemptState(TaskAttemptID attemptId, Optional<Integer> inputTaskIndex, Optional<Integer> outputTaskIndex)
+    {
+        this.attemptId = attemptId;
+        this.inputTaskIndex = inputTaskIndex;
+        this.outputTaskIndex = outputTaskIndex;
+    }
+
+    @JsonCreator
+    AttemptState(
+            @JsonProperty("attempt") String attemptId,
+            @JsonProperty("inputTaskIndex") Optional<Integer> inputTaskIndex,
+            @JsonProperty("outputTaskIndex") Optional<Integer> outputTaskIndex,
+            @JsonProperty("exception") Optional<String> exception,
+            @JsonProperty("userDataException") boolean userDataException,
+            @JsonProperty("inputTaskReport") Optional<TaskReport> inputTaskReport,
+            @JsonProperty("outputTaskReport") Optional<TaskReport> outputTaskReport)
+    {
+        this(TaskAttemptID.forName(attemptId),
+                inputTaskIndex, outputTaskIndex,
+                exception, userDataException,
+                inputTaskReport, outputTaskReport);
+    }
+
+    public AttemptState(
+            TaskAttemptID attemptId,
+            Optional<Integer> inputTaskIndex,
+            Optional<Integer> outputTaskIndex,
+            Optional<String> exception,
+            boolean userDataException,
+            Optional<TaskReport> inputTaskReport,
+            Optional<TaskReport> outputTaskReport)
+    {
+        this.attemptId = attemptId;
+        this.inputTaskIndex = inputTaskIndex;
+        this.outputTaskIndex = outputTaskIndex;
+        this.exception = exception;
+        this.userDataException = userDataException;
+        this.inputTaskReport = inputTaskReport;
+        this.outputTaskReport = outputTaskReport;
+    }
+
+    @JsonIgnore
+    public TaskAttemptID getAttemptId()
+    {
+        return attemptId;
+    }
+
+    @JsonProperty("attempt")
+    public String getAttemptIdString()
+    {
+        return attemptId.toString();
+    }
+
+    @JsonProperty("inputTaskIndex")
+    public Optional<Integer> getInputTaskIndex()
+    {
+        return inputTaskIndex;
+    }
+
+    @JsonProperty("outputTaskIndex")
+    public Optional<Integer> getOutputTaskIndex()
+    {
+        return outputTaskIndex;
+    }
+
+    @JsonIgnore
+    public void setException(Throwable exception)
+    {
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        try (PrintStream ps = new PrintStream(os, false, "UTF-8")) {
+            exception.printStackTrace(ps);
+        } catch (UnsupportedEncodingException ex) {
+            throw new RuntimeException(ex);
+        }
+        setException(
+                new String(os.toByteArray(), StandardCharsets.UTF_8),
+                UserDataExceptions.isUserDataException(exception));
+    }
+
+    @JsonIgnore
+    public void setException(String exception, boolean userDataException)
+    {
+        this.exception = Optional.of(exception);
+        this.userDataException = userDataException;
+    }
+
+    @JsonProperty("exception")
+    public Optional<String> getException()
+    {
+        return exception;
+    }
+
+    @JsonProperty("userDataException")
+    public boolean isUserDataException()
+    {
+        return userDataException;
+    }
+
+    @JsonProperty("inputTaskReport")
+    public Optional<TaskReport> getInputTaskReport()
+    {
+        return inputTaskReport;
+    }
+
+    @JsonProperty("outputTaskReport")
+    public Optional<TaskReport> getOutputTaskReport()
+    {
+        return outputTaskReport;
+    }
+
+    @JsonIgnore
+    public void setInputTaskReport(TaskReport inputTaskReport)
+    {
+        this.inputTaskReport = Optional.of(inputTaskReport);
+    }
+
+    @JsonIgnore
+    public void setOutputTaskReport(TaskReport outputTaskReport)
+    {
+        this.outputTaskReport = Optional.of(outputTaskReport);
+    }
+
+    public void writeTo(OutputStream out, ModelManager modelManager) throws IOException
+    {
+        String s = modelManager.writeObject(this);
+        out.write(s.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public static AttemptState readFrom(InputStream in, ModelManager modelManager) throws IOException
+    {
+        // If InputStream contains partial JSON (like '{"key":"va'), this method throws EOFException
+        Scanner s = new Scanner(in, "UTF-8").useDelimiter("\\A");  // TODO
+        if (s.hasNext()) {
+            return modelManager.readObject(AttemptState.class, s.next());
+        } else {
+            throw new EOFException("JSON is not included in the attempt state file.");
+        }
+    }
+}

--- a/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/BufferWritable.java
+++ b/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/BufferWritable.java
@@ -1,0 +1,74 @@
+package org.embulk.executor.mapreduce;
+
+import java.io.IOException;
+import java.io.DataOutput;
+import java.io.DataInput;
+import org.apache.hadoop.io.WritableComparable;
+import org.apache.hadoop.io.WritableUtils;
+import org.apache.hadoop.io.WritableComparator;
+import org.embulk.spi.Buffer;
+
+public class BufferWritable
+        implements WritableComparable<BufferWritable>
+{
+    private Buffer buffer;
+
+    public BufferWritable() { }
+
+    public void set(Buffer buffer)
+    {
+        this.buffer = buffer;
+    }
+
+    public Buffer get()
+    {
+        return buffer;
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException
+    {
+        WritableUtils.writeVInt(out, buffer.limit());
+        out.write(buffer.array(), buffer.offset(), buffer.limit());
+    }
+
+    @Override
+    public void readFields(DataInput in) throws IOException
+    {
+        int size = WritableUtils.readVInt(in);
+        byte[] bytes = new byte[size];  // TODO usa buffer allocator?
+        in.readFully(bytes, 0, size);
+        Buffer newBuffer = Buffer.wrap(bytes);
+        if (buffer != null) {
+            buffer.release();
+        }
+        buffer = newBuffer;
+    }
+
+    @Override
+    public int compareTo(BufferWritable o)
+    {
+        return WritableComparator.compareBytes(
+                buffer.array(), buffer.offset(), buffer.limit(),
+                o.buffer.array(), o.buffer.offset(), o.buffer.limit());
+    }
+
+    @Override
+    public boolean equals(Object other)
+    {
+        if (!(other instanceof BufferWritable)) {
+            return false;
+        }
+        BufferWritable o = (BufferWritable) other;
+        if (buffer == null) {
+            return o.buffer == null;
+        }
+        return buffer.equals(o.buffer);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return buffer.hashCode();
+    }
+}

--- a/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/BufferedPagePartitioner.java
+++ b/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/BufferedPagePartitioner.java
@@ -1,0 +1,167 @@
+package org.embulk.executor.mapreduce;
+
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Iterator;
+import org.embulk.spi.Page;
+import org.embulk.spi.PageOutput;
+import org.embulk.spi.PageBuilder;
+import org.embulk.spi.PageReader;
+import org.embulk.spi.Schema;
+import org.embulk.spi.Column;
+import org.embulk.spi.ColumnVisitor;
+import org.embulk.spi.BufferAllocator;
+
+public class BufferedPagePartitioner
+{
+    public static interface PartitionedPageOutput
+    {
+        public void add(PartitionKey key, Page value);
+
+        public void finish();
+
+        public void close();
+    }
+
+    private static class ForwardRecordColumnVisitor
+            implements ColumnVisitor
+    {
+        private final PageReader source;
+        private final PageBuilder destination;
+
+        public ForwardRecordColumnVisitor(PageReader source, PageBuilder destination)
+        {
+            this.source = source;
+            this.destination = destination;
+        }
+
+        public void booleanColumn(Column column)
+        {
+            if (source.isNull(column)) {
+                destination.setNull(column);
+            } else {
+                destination.setBoolean(column, source.getBoolean(column));
+            }
+        }
+
+        public void longColumn(Column column)
+        {
+            if (source.isNull(column)) {
+                destination.setNull(column);
+            } else {
+                destination.setLong(column, source.getLong(column));
+            }
+        }
+
+        public void doubleColumn(Column column)
+        {
+            if (source.isNull(column)) {
+                destination.setNull(column);
+            } else {
+                destination.setDouble(column, source.getDouble(column));
+            }
+        }
+
+        public void stringColumn(Column column)
+        {
+            if (source.isNull(column)) {
+                destination.setNull(column);
+            } else {
+                destination.setString(column, source.getString(column));
+            }
+        }
+
+        public void jsonColumn(Column column)
+        {
+            if (source.isNull(column)) {
+                destination.setNull(column);
+            } else {
+                destination.setJson(column, source.getJson(column));
+            }
+        }
+
+        public void timestampColumn(Column column)
+        {
+            if (source.isNull(column)) {
+                destination.setNull(column);
+            } else {
+                destination.setTimestamp(column, source.getTimestamp(column));
+            }
+        }
+    }
+
+    private final BufferAllocator bufferAllocator;
+    private final Schema schema;
+    private final Partitioner partitioner;
+    private final int maxPageBufferCount;
+    private final PartitionedPageOutput output;
+
+    private final Map<PartitionKey, PageBuilder> hash = new HashMap<PartitionKey, PageBuilder>();
+
+    public BufferedPagePartitioner(BufferAllocator bufferAllocator, Schema schema,
+            Partitioner partitioner, int maxPageBufferCount, PartitionedPageOutput output)
+    {
+        this.bufferAllocator = bufferAllocator;
+        this.schema = schema;
+        this.partitioner = partitioner;
+        this.maxPageBufferCount = maxPageBufferCount;
+        this.output = output;
+    }
+
+    public void add(PageReader record)
+    {
+        PartitionKey searchKey = partitioner.updateKey(record);
+        PageBuilder builder = hash.get(searchKey);
+        if (builder == null) {
+            if (hash.size() >= maxPageBufferCount) {
+                try (PageBuilder b = removeMostUnsed(hash)) {
+                    b.finish();
+                }
+            }
+            final PartitionKey key = searchKey.clone();
+            builder = new PageBuilder(bufferAllocator, schema, new PageOutput() {
+                public void add(Page page)
+                {
+                    output.add(key, page);
+                }
+
+                public void finish()
+                { }
+
+                public void close()
+                { }
+            });
+            hash.put(key, builder);
+        }
+        builder.getSchema().visitColumns(new ForwardRecordColumnVisitor(record, builder));
+        builder.addRecord();
+    }
+
+    private PageBuilder removeMostUnsed(Map<PartitionKey, PageBuilder> hash)
+    {
+        // TODO remove the largest buffer
+        Iterator<Map.Entry<PartitionKey, PageBuilder>> ite = hash.entrySet().iterator();
+        PageBuilder builder = ite.next().getValue();
+        ite.remove();
+        return builder;
+    }
+
+    public void finish()
+    {
+        for (PageBuilder builder : hash.values()) {
+            builder.finish();
+        }
+        output.finish();
+    }
+
+    public void close()
+    {
+        Iterator<Map.Entry<PartitionKey, PageBuilder>> ite = hash.entrySet().iterator();
+        while (ite.hasNext()) {
+            PageBuilder builder = ite.next().getValue();
+            builder.close();
+            ite.remove();
+        }
+        output.close();
+    }
+}

--- a/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/DefaultEmbulkFactory.java
+++ b/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/DefaultEmbulkFactory.java
@@ -1,0 +1,13 @@
+package org.embulk.executor.mapreduce;
+
+import org.embulk.config.ConfigSource;
+import org.embulk.EmbulkEmbed;
+
+public class DefaultEmbulkFactory
+{
+    public EmbulkEmbed.Bootstrap bootstrap(ConfigSource systemConfig)
+    {
+        return new EmbulkEmbed.Bootstrap()
+            .setSystemConfig(systemConfig);
+    }
+}

--- a/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/EmbulkInputFormat.java
+++ b/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/EmbulkInputFormat.java
@@ -1,0 +1,37 @@
+package org.embulk.executor.mapreduce;
+
+import java.util.List;
+import java.io.IOException;
+import com.google.common.collect.ImmutableList;
+import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.InputFormat;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.JobContext;
+
+public class EmbulkInputFormat
+        extends InputFormat<IntWritable, NullWritable>
+{
+    @Override
+    public List<InputSplit> getSplits(JobContext context)
+        throws IOException, InterruptedException
+    {
+        // TODO combining multiple tasks to one mapper is not implemented yet.
+        int taskCount = EmbulkMapReduce.getMapTaskCount(context.getConfiguration());
+        ImmutableList.Builder<InputSplit> builder = ImmutableList.builder();
+        for (int i=0; i < taskCount; i++) {
+            builder.add(new EmbulkInputSplit(new int[] { i }));
+        }
+        return builder.build();
+    }
+
+    @Override
+    public RecordReader<IntWritable, NullWritable> createRecordReader(
+            InputSplit split, TaskAttemptContext context)
+        throws IOException, InterruptedException
+    {
+        return new EmbulkRecordReader((EmbulkInputSplit) split);
+    }
+}

--- a/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/EmbulkInputSplit.java
+++ b/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/EmbulkInputSplit.java
@@ -1,0 +1,61 @@
+package org.embulk.executor.mapreduce;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapreduce.InputSplit;
+
+public class EmbulkInputSplit
+        extends InputSplit
+        implements Writable
+{
+    private int[] taskIndexes;
+
+    public EmbulkInputSplit()
+    {
+        this(new int[0]);
+    }
+
+    public EmbulkInputSplit(int[] taskIndexes)
+    {
+        this.taskIndexes = taskIndexes;
+    }
+
+    public int[] getTaskIndexes()
+    {
+        return taskIndexes;
+    }
+
+    @Override
+    public long getLength()
+    {
+        return taskIndexes.length;
+    }
+
+    @Override
+    public String[] getLocations()
+    {
+        return new String[0];
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException
+    {
+        out.writeInt(taskIndexes.length);
+        for (int taskIndex : taskIndexes) {
+            out.writeInt(taskIndex);
+        }
+    }
+
+    @Override
+    public void readFields(DataInput in) throws IOException
+    {
+        int c = in.readInt();
+        int[] taskIndexes = new int[c];
+        for (int i=0; i < c; i++) {
+            taskIndexes[i] = in.readInt();
+        }
+        this.taskIndexes = taskIndexes;
+    }
+}

--- a/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/EmbulkMapReduce.java
+++ b/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/EmbulkMapReduce.java
@@ -1,0 +1,615 @@
+package org.embulk.executor.mapreduce;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.io.File;
+import java.io.InputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.EOFException;
+import java.io.InterruptedIOException;
+import java.lang.reflect.Method;
+import java.lang.reflect.InvocationTargetException;
+import com.google.inject.Injector;
+import com.google.common.base.Optional;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jruby.embed.ScriptingContainer;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.LocalDirAllocator;
+import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.Counters;
+import org.apache.hadoop.mapreduce.TaskAttemptID;
+import org.apache.hadoop.mapreduce.Mapper;
+import org.apache.hadoop.mapreduce.Reducer;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.MRConfig;
+import org.embulk.config.ModelManager;
+import org.embulk.config.ConfigSource;
+import org.embulk.config.ConfigLoader;
+import org.embulk.config.DataSourceImpl;
+import org.embulk.config.TaskReport;
+import org.embulk.spi.BufferAllocator;
+import org.embulk.spi.Exec;
+import org.embulk.spi.ExecAction;
+import org.embulk.spi.ExecSession;
+import org.embulk.spi.ProcessTask;
+import org.embulk.spi.util.Executors;
+import org.embulk.spi.util.RetryExecutor.Retryable;
+import org.embulk.spi.util.RetryExecutor.RetryGiveupException;
+import org.embulk.EmbulkEmbed;
+import org.slf4j.Logger;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.embulk.spi.util.RetryExecutor.retryExecutor;
+
+public class EmbulkMapReduce
+{
+    private static final String EMBULK_FACTORY_CLASS = "embulk_factory_class";
+    private static final String SYSTEM_CONFIG_SERVICE_CLASS = "mapreduce_service_class";
+
+    private static final String CK_SYSTEM_CONFIG = "embulk.mapreduce.systemConfig";
+    private static final String CK_STATE_DIRECTORY_PATH = "embulk.mapreduce.stateDirectorypath";
+    private static final String CK_TASK_COUNT = "embulk.mapreduce.taskCount";
+    private static final String CK_RETRY_TASKS = "embulk.mapreduce.retryTasks";
+    private static final String CK_TASK = "embulk.mapreduce.task";
+    private static final String CK_PLUGIN_ARCHIVE_SPECS = "embulk.mapreduce.pluginArchive.specs";
+
+    private static final String PLUGIN_ARCHIVE_FILE_NAME = "gems.zip";
+
+    public static void setSystemConfig(Configuration config, ModelManager modelManager, ConfigSource systemConfig)
+    {
+        config.set(CK_SYSTEM_CONFIG, modelManager.writeObject(systemConfig));
+    }
+
+    public static ConfigSource getSystemConfig(Configuration config)
+    {
+        try {
+            ModelManager bootstrapModelManager = new ModelManager(null, new ObjectMapper());
+            String json = config.get(CK_SYSTEM_CONFIG);
+            try (InputStream in = new ByteArrayInputStream(json.getBytes(UTF_8))) {
+                return new ConfigLoader(bootstrapModelManager).fromJson(in);
+            }
+        } catch (IOException e) {
+            throw Throwables.propagate(e);
+        }
+    }
+
+    public static void setMapTaskCount(Configuration config, int taskCount)
+    {
+        config.setInt(CK_TASK_COUNT, taskCount);
+    }
+
+    public static int getMapTaskCount(Configuration config)
+    {
+        return config.getInt(CK_TASK_COUNT, 0);
+    }
+
+    public static void setRetryTasks(Configuration config, boolean enabled)
+    {
+        config.setBoolean(CK_RETRY_TASKS, enabled);
+    }
+
+    public static boolean getRetryTasks(Configuration config)
+    {
+        return config.getBoolean(CK_RETRY_TASKS, false);
+    }
+
+    public static void setStateDirectoryPath(Configuration config, Path path)
+    {
+        config.set(CK_STATE_DIRECTORY_PATH, path.toString());
+    }
+
+    public static Path getStateDirectoryPath(Configuration config)
+    {
+        return new Path(config.get(CK_STATE_DIRECTORY_PATH));
+    }
+
+    public static void setExecutorTask(Configuration config, ModelManager modelManager, MapReduceExecutorTask task)
+    {
+        config.set(CK_TASK, modelManager.writeObject(task));
+    }
+
+    public static MapReduceExecutorTask getExecutorTask(Injector injector, Configuration config)
+    {
+        return injector.getInstance(ModelManager.class).readObject(MapReduceExecutorTask.class,
+                config.get(CK_TASK));
+    }
+
+    public static EmbulkEmbed.Bootstrap newEmbulkBootstrap(Configuration config)
+    {
+        ConfigSource systemConfig = getSystemConfig(config);
+
+        // for warnings of old versions
+        if (!systemConfig.get(String.class, SYSTEM_CONFIG_SERVICE_CLASS, "org.embulk.EmbulkService").equals("org.embulk.EmbulkService")) {
+            throw new RuntimeException("System config 'mapreduce_service_class' is not supported any more. Please use 'embulk_factory_class' instead");
+        }
+
+        String factoryClassName = systemConfig.get(String.class, EMBULK_FACTORY_CLASS, DefaultEmbulkFactory.class.getName());
+
+        try {
+            Class<?> factoryClass = Class.forName(factoryClassName);
+            Object factory = factoryClass.newInstance();
+
+            Object bootstrap;
+            try {
+                // factory.bootstrap(ConfigSource masterSystemConfig, ConfigSource executorParams)
+                Method method = factoryClass.getMethod("bootstrap", ConfigSource.class, ConfigSource.class);
+                Map<String, String> hadoopConfig = config.getValByRegex("");
+                ConfigSource executorParams = new DataSourceImpl(new ModelManager(null, new ObjectMapper())).set("hadoopConfig", hadoopConfig).getNested("hadoopConfig");  // TODO add a method to embulk that creates an empty DataSource instance
+                bootstrap = method.invoke(factory, systemConfig, executorParams);
+            }
+            catch (NoSuchMethodException ex) {
+                // factory.bootstrap(ConfigSource masterSystemConfig)
+                bootstrap = factoryClass.getMethod("bootstrap", ConfigSource.class).invoke(factory, systemConfig);
+            }
+
+            return (EmbulkEmbed.Bootstrap) bootstrap;
+
+        }
+        catch (InvocationTargetException ex) {
+            throw Throwables.propagate(ex.getCause());
+        }
+        catch (ClassNotFoundException | NoSuchMethodException | InstantiationException | IllegalAccessException | IllegalArgumentException ex) {
+            throw Throwables.propagate(ex);
+        }
+    }
+
+    public static class JobStatus
+    {
+        private final boolean completed;
+        private final float mapProgress;
+        private final float reduceProgress;
+
+        public JobStatus(boolean completed, float mapProgress, float reduceProgress)
+        {
+            this.completed = completed;
+            this.mapProgress = mapProgress;
+            this.reduceProgress = reduceProgress;
+        }
+
+        public boolean isComplete()
+        {
+            return completed;
+        }
+
+        public float getMapProgress()
+        {
+            return mapProgress;
+        }
+
+        public float getReduceProgress()
+        {
+            return reduceProgress;
+        }
+    }
+
+    public static JobStatus getJobStatus(final Job job) throws IOException
+    {
+        return hadoopOperationWithRetry("Getting job status", new Callable<JobStatus>() {
+            public JobStatus call() throws IOException
+            {
+                return new JobStatus(job.isComplete(), job.mapProgress(), job.reduceProgress());
+            }
+        });
+    }
+
+    public static Counters getJobCounters(final Job job) throws IOException
+    {
+        return hadoopOperationWithRetry("Getting job counters", new Callable<Counters>() {
+            public Counters call() throws IOException
+            {
+                return job.getCounters();
+            }
+        });
+    }
+
+    public static List<TaskAttemptID> listAttempts(final Configuration config,
+            final Path stateDir) throws IOException
+    {
+        return hadoopOperationWithRetry("Getting list of attempt state files on "+stateDir, new Callable<List<TaskAttemptID>>() {
+            public List<TaskAttemptID> call() throws IOException
+            {
+                FileStatus[] stats = stateDir.getFileSystem(config).listStatus(stateDir);
+                ImmutableList.Builder<TaskAttemptID> builder = ImmutableList.builder();
+                for (FileStatus stat : stats) {
+                    if (stat.getPath().getName().startsWith("attempt_") && stat.isFile()) {
+                        String name = stat.getPath().getName();
+                        TaskAttemptID id;
+                        try {
+                            id = TaskAttemptID.forName(name);
+                        } catch (Exception ex) {
+                            // ignore this file
+                            continue;
+                        }
+                        builder.add(id);
+                    }
+                }
+                return builder.build();
+            }
+        });
+    }
+
+    public static void writePluginArchive(final Configuration config, final Path stateDir,
+            final PluginArchive archive, final ModelManager modelManager) throws IOException
+    {
+        final Path path = new Path(stateDir, PLUGIN_ARCHIVE_FILE_NAME);
+        hadoopOperationWithRetry("Writing plugin archive to "+path, new Callable<Void>() {
+            public Void call() throws IOException
+            {
+                stateDir.getFileSystem(config).mkdirs(stateDir);
+                try (FSDataOutputStream out = path.getFileSystem(config).create(path, true)) {
+                    List<PluginArchive.GemSpec> specs = archive.dump(out);
+                    config.set(CK_PLUGIN_ARCHIVE_SPECS, modelManager.writeObject(specs));
+                }
+                return null;
+            }
+        });
+    }
+
+    public static class GemSpecListType extends ArrayList<PluginArchive.GemSpec>
+    { }
+
+    public static PluginArchive readPluginArchive(final File localDirectory, final Configuration config,
+            Path stateDir, final ModelManager modelManager) throws IOException
+    {
+        final Path path = new Path(stateDir, PLUGIN_ARCHIVE_FILE_NAME);
+        return hadoopOperationWithRetry("Reading plugin archive file from "+path, new Callable<PluginArchive>() {
+                public PluginArchive call() throws IOException
+                {
+                    List<PluginArchive.GemSpec> specs = modelManager.readObject(
+                            GemSpecListType.class,
+                            config.get(CK_PLUGIN_ARCHIVE_SPECS));
+                    try (FSDataInputStream in = path.getFileSystem(config).open(path)) {
+                        return PluginArchive.load(localDirectory, specs, in);
+                    }
+                }
+        });
+    }
+
+    public static void writeAttemptStateFile(final Configuration config,
+            Path stateDir, final AttemptState state, final ModelManager modelManager) throws IOException
+    {
+        final Path path = new Path(stateDir, state.getAttemptId().toString());
+        hadoopOperationWithRetry("Writing attempt state file to "+path, new Callable<Void>() {
+            public Void call() throws IOException
+            {
+                try (FSDataOutputStream out = path.getFileSystem(config).create(path, true)) {
+                    state.writeTo(out, modelManager);
+                }
+                return null;
+            }
+        });
+    }
+
+    public static AttemptState readAttemptStateFile(final Configuration config,
+            Path stateDir, TaskAttemptID id, final ModelManager modelManager,
+            final boolean concurrentWriteIsPossible) throws IOException
+    {
+        final Logger log = Exec.getLogger(EmbulkMapReduce.class);
+        final Path path = new Path(stateDir, id.toString());
+        try {
+            return retryExecutor()
+                    .withRetryLimit(5)
+                    .withInitialRetryWait(2 * 1000)
+                    .withMaxRetryWait(20 * 1000)
+                    .runInterruptible(new Retryable<AttemptState>() {
+                        @Override
+                        public AttemptState call() throws IOException
+                        {
+                            try (FSDataInputStream in = path.getFileSystem(config).open(path)) {
+                                return AttemptState.readFrom(in, modelManager);
+                            }
+                        }
+
+                        @Override
+                        public boolean isRetryableException(Exception exception)
+                        {
+                            // AttemptState.readFrom throws 4 types of exceptions:
+                            //
+                            //   concurrentWriteIsPossible == true:
+                            //      a) EOFException: race between readFrom and writeTo. See comments on AttemptState.readFrom.
+                            //      b) EOFException: file exists but its format is invalid because this task is retried and last job/attempt left corrupted files (such as empty, partially written, etc)
+                            //      c) IOException "Cannot obtain block length for LocatedBlock": HDFS-1058. See https://github.com/embulk/embulk-executor-mapreduce/pull/3
+                            //      d) IOException: FileSystem is not working
+                            //   concurrentWriteIsPossible == false:
+                            //      e) EOFException: file exists but its format is invalid because this task is retried and last job/attempt left corrupted files (such as empty, partially written, etc)
+                            //      f) IOException: FileSystem is not working
+                            //
+                            if (exception instanceof EOFException) {
+                                // a) and b) don't need retrying. See MapReduceExecutor.getAttemptReports that ignores EOFException.
+                                // e) is not recoverable.
+                                return false;
+                            }
+                            return true;
+                        }
+
+                        @Override
+                        public void onRetry(Exception exception, int retryCount, int retryLimit, int retryWait)
+                                throws RetryGiveupException
+                        {
+                            log.warn("Reading a state file failed. Retrying {}/{} after {} seconds. Message: {}",
+                                    retryCount, retryLimit, retryWait, exception.getMessage(),
+                                    retryCount % 3 == 0 ? exception : null);
+                        }
+
+                        @Override
+                        public void onGiveup(Exception firstException, Exception lastException)
+                                throws RetryGiveupException
+                        { }
+                    });
+        } catch (RetryGiveupException e) {
+            Throwables.propagateIfInstanceOf(e.getCause(), IOException.class);
+            throw Throwables.propagate(e.getCause());
+        } catch (InterruptedException e) {
+            throw new InterruptedIOException();
+        }
+    }
+
+    private static <T> T hadoopOperationWithRetry(final String message, final Callable<T> callable) throws IOException
+    {
+        return hadoopOperationWithRetry(Exec.getLogger(EmbulkMapReduce.class), message, callable);
+    }
+
+    private static <T> T hadoopOperationWithRetry(final Logger log,
+            final String message, final Callable<T> callable) throws IOException
+    {
+        try {
+            return retryExecutor()
+                    .withRetryLimit(5)
+                    .withInitialRetryWait(2 * 1000)
+                    .withMaxRetryWait(20 * 1000)
+                    .runInterruptible(new Retryable<T>() {
+                        @Override
+                        public T call() throws Exception
+                        {
+                            return callable.call();
+                        }
+
+                        @Override
+                        public boolean isRetryableException(Exception exception)
+                        {
+                            return true;
+                        }
+
+                        @Override
+                        public void onRetry(Exception exception, int retryCount, int retryLimit, int retryWait)
+                                throws RetryGiveupException
+                        {
+                            log.warn("{} failed. Retrying {}/{} after {} seconds. Message: {}",
+                                    message, retryCount, retryLimit, retryWait, exception.getMessage(),
+                                    retryCount % 3 == 0 ? exception : null);
+                        }
+
+                        @Override
+                        public void onGiveup(Exception firstException, Exception lastException)
+                                throws RetryGiveupException
+                        { }
+                    });
+        } catch (RetryGiveupException e) {
+            Throwables.propagateIfInstanceOf(e.getCause(), IOException.class);
+            throw Throwables.propagate(e.getCause());
+        } catch (InterruptedException e) {
+            throw new InterruptedIOException();
+        }
+    }
+
+    public static class SessionRunner
+    {
+        private final Configuration config;
+        private final EmbulkEmbed embed;
+        private final MapReduceExecutorTask task;
+        private final ExecSession session;
+        private final File localGemPath;
+
+        public SessionRunner(TaskAttemptContext context)
+        {
+            this.config = context.getConfiguration();
+            this.embed = newEmbulkBootstrap(context.getConfiguration()).initialize();  // TODO use initializeCloseable?
+            this.task = getExecutorTask(embed.getInjector(), context.getConfiguration());
+            this.session = ExecSession.builder(embed.getInjector()).fromExecConfig(task.getExecConfig()).build();
+
+            try {
+                // LocalDirAllocator allocates a directory for a job. Here adds attempt id to the path
+                // so that attempts running on the same machine don't conflict each other.
+                LocalDirAllocator localDirAllocator = new LocalDirAllocator(MRConfig.LOCAL_DIR);
+                String dirName = context.getTaskAttemptID().toString() + "/embulk_gems";
+                Path destPath = localDirAllocator.getLocalPathForWrite(dirName, config);
+                this.localGemPath = new File(destPath.toString());
+            } catch (IOException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+
+        public PluginArchive readPluginArchive() throws IOException
+        {
+            localGemPath.mkdirs();
+            return EmbulkMapReduce.readPluginArchive(localGemPath, config, getStateDirectoryPath(config), embed.getModelManager());
+        }
+
+        public Configuration getConfiguration()
+        {
+            return config;
+        }
+
+        public ModelManager getModelManager()
+        {
+            return embed.getModelManager();
+        }
+
+        public BufferAllocator getBufferAllocator()
+        {
+            return embed.getBufferAllocator();
+        }
+
+        public ScriptingContainer getScriptingContainer()
+        {
+            return embed.getInjector().getInstance(ScriptingContainer.class);
+        }
+
+        public MapReduceExecutorTask getMapReduceExecutorTask()
+        {
+            return task;
+        }
+
+        public ExecSession getExecSession()
+        {
+            return session;
+        }
+
+        public <T> T execSession(ExecAction<T> action) throws IOException, InterruptedException
+        {
+            try {
+                return Exec.doWith(session, action);
+            } catch (ExecutionException e) {
+                Throwables.propagateIfInstanceOf(e.getCause(), IOException.class);
+                Throwables.propagateIfInstanceOf(e.getCause(), InterruptedException.class);
+                throw Throwables.propagate(e.getCause());
+            }
+        }
+
+        public void deleteTempFiles()
+        {
+            // TODO delete localGemPath
+        }
+    }
+
+    public static class AttemptStateUpdateHandler
+            implements Executors.ProcessStateCallback
+    {
+        private final Configuration config;
+        private final Path stateDir;
+        private final ModelManager modelManager;
+        private final AttemptState state;
+
+        public AttemptStateUpdateHandler(SessionRunner runner, AttemptState state)
+        {
+            this.config = runner.getConfiguration();
+            this.stateDir = getStateDirectoryPath(config);
+            this.state = state;
+            this.modelManager = runner.getModelManager();
+        }
+
+        @Override
+        public void started()
+        {
+            try {
+                writeAttemptStateFile(config, stateDir, state, modelManager);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public void inputCommitted(TaskReport report)
+        {
+            state.setInputTaskReport(report);
+            try {
+                writeAttemptStateFile(config, stateDir, state, modelManager);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public void outputCommitted(TaskReport report)
+        {
+            state.setOutputTaskReport(report);
+            try {
+                writeAttemptStateFile(config, stateDir, state, modelManager);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        public void setException(Throwable ex) throws IOException
+        {
+            state.setException(ex);
+            writeAttemptStateFile(config, stateDir, state, modelManager);
+        }
+    }
+
+    public static class EmbulkMapper
+            extends Mapper<IntWritable, NullWritable, NullWritable, NullWritable>
+    {
+        private Context context;
+        private SessionRunner runner;
+        private boolean retryTasks;
+
+        @Override
+        public void setup(Context context) throws IOException, InterruptedException
+        {
+            this.context = context;
+            this.runner = new SessionRunner(context);
+            this.retryTasks = EmbulkMapReduce.getRetryTasks(context.getConfiguration());
+
+            runner.execSession(new ExecAction<Void>() {  // for Exec.getLogger
+                public Void run() throws IOException
+                {
+                    runner.readPluginArchive().restoreLoadPathsTo(runner.getScriptingContainer());
+                    return null;
+                }
+            });
+        }
+
+        @Override
+        public void map(IntWritable key, NullWritable value, final Context context) throws IOException, InterruptedException
+        {
+            final int taskIndex = key.get();
+
+            runner.execSession(new ExecAction<Void>() {
+                public Void run() throws Exception
+                {
+                    process(context, taskIndex);
+                    return null;
+                }
+            });
+        }
+
+        private void process(final Context context, int taskIndex) throws IOException, InterruptedException
+        {
+            ProcessTask task = runner.getMapReduceExecutorTask().getProcessTask();
+
+            AttemptStateUpdateHandler handler = new AttemptStateUpdateHandler(runner,
+                    new AttemptState(context.getTaskAttemptID(), Optional.of(taskIndex), Optional.of(taskIndex)));
+
+            try {
+                Executors.process(runner.getExecSession(), task, taskIndex, handler);
+            }
+            catch (Exception ex) {
+                try {
+                    handler.setException(ex);
+                } catch (Throwable e) {
+                    e.addSuppressed(ex);
+                    throw e;
+                }
+                if (retryTasks) {
+                    throw ex;
+                }
+            }
+        }
+    }
+
+    public static class EmbulkReducer
+            extends Reducer<NullWritable, NullWritable, NullWritable, NullWritable>
+    {
+        private IntWritable result = new IntWritable();
+
+        @Override
+        public void reduce(NullWritable key, Iterable<NullWritable> values, Context context)
+                throws IOException, InterruptedException
+        {
+            // do nothing
+        }
+    }
+}

--- a/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/EmbulkPartitioningMapReduce.java
+++ b/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/EmbulkPartitioningMapReduce.java
@@ -1,0 +1,321 @@
+package org.embulk.executor.mapreduce;
+
+import java.util.List;
+import java.util.Iterator;
+import java.io.IOException;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.Mapper;
+import org.apache.hadoop.mapreduce.Reducer;
+import org.embulk.config.ModelManager;
+import org.embulk.config.TaskReport;
+import org.embulk.config.ConfigDiff;
+import org.embulk.config.TaskSource;
+import org.embulk.config.ConfigSource;
+import org.embulk.spi.Exec;
+import org.embulk.spi.ExecAction;
+import org.embulk.spi.ExecSession;
+import org.embulk.spi.Schema;
+import org.embulk.spi.Page;
+import org.embulk.spi.PageReader;
+import org.embulk.spi.PageOutput;
+import org.embulk.spi.BufferAllocator;
+import org.embulk.spi.InputPlugin;
+import org.embulk.spi.OutputPlugin;
+import org.embulk.spi.FilterPlugin;
+import org.embulk.spi.ProcessTask;
+import org.embulk.spi.TransactionalPageOutput;
+import org.embulk.spi.util.Filters;
+import org.embulk.spi.util.Executors;
+import org.embulk.executor.mapreduce.EmbulkMapReduce.SessionRunner;
+import org.embulk.executor.mapreduce.BufferedPagePartitioner.PartitionedPageOutput;
+import org.embulk.executor.mapreduce.EmbulkMapReduce.AttemptStateUpdateHandler;
+import static org.embulk.executor.mapreduce.MapReduceExecutor.newPartitioning;
+
+public class EmbulkPartitioningMapReduce
+{
+    public static class EmbulkPartitioningMapper
+            extends Mapper<IntWritable, NullWritable, BufferWritable, PageWritable>
+    {
+        private Context context;
+        private SessionRunner runner;
+
+        @Override
+        public void setup(Context context) throws IOException, InterruptedException
+        {
+            this.context = context;
+            this.runner = new SessionRunner(context);
+
+            runner.execSession(new ExecAction<Void>() {  // for Exec.getLogger
+                public Void run() throws IOException
+                {
+                    runner.readPluginArchive().restoreLoadPathsTo(runner.getScriptingContainer());
+                    return null;
+                }
+            });
+        }
+
+        @Override
+        public void map(IntWritable key, NullWritable value, final Context context) throws IOException, InterruptedException
+        {
+            final int taskIndex = key.get();
+
+            runner.execSession(new ExecAction<Void>() {
+                public Void run() throws Exception
+                {
+                    process(context, taskIndex);
+                    return null;
+                }
+            });
+        }
+
+        private void process(final Context context, int taskIndex) throws IOException, InterruptedException
+        {
+            ProcessTask task = runner.getMapReduceExecutorTask().getProcessTask();
+            ExecSession exec = runner.getExecSession();
+
+            // input and filters run at mapper
+            InputPlugin inputPlugin = exec.newPlugin(InputPlugin.class, task.getInputPluginType());
+            List<FilterPlugin> filterPlugins = Filters.newFilterPlugins(exec, task.getFilterPluginTypes());
+
+            // output writes pages with partitioning key to the Context
+            Partitioning partitioning = newPartitioning(runner.getMapReduceExecutorTask().getPartitioningType().get());
+            final Partitioner partitioner = partitioning.newPartitioner(runner.getMapReduceExecutorTask().getPartitioningTask().get());
+            OutputPlugin outputPlugin = new MapperOutputPlugin(
+                    runner.getBufferAllocator(), partitioner,
+                    128,  // TODO configurable
+                    new PartitionedPageOutput() {
+                        private final BufferWritable keyWritable = new BufferWritable();
+                        private final PageWritable valueWritable = new PageWritable();
+
+                        {
+                            keyWritable.set(partitioner.newKeyBuffer());
+                        }
+
+                        @Override
+                        public void add(PartitionKey key, Page value)
+                        {
+                            try {
+                                key.dump(keyWritable.get());
+                                valueWritable.set(value);
+                                context.write(keyWritable, valueWritable);
+                            } catch (IOException | InterruptedException ex) {
+                                throw new RuntimeException(ex);
+                            } finally {
+                                value.release();
+                            }
+                        }
+
+                        @Override
+                        public void finish()
+                        { }
+
+                        @Override
+                        public void close()
+                        { }
+                    });
+
+            AttemptStateUpdateHandler handler = new AttemptStateUpdateHandler(runner,
+                    new AttemptState(context.getTaskAttemptID(), Optional.of(taskIndex), Optional.<Integer>absent()));
+
+            try {
+                Executors.process(exec, taskIndex,
+                    inputPlugin, task.getInputSchema(), task.getInputTaskSource(),
+                    filterPlugins, task.getFilterSchemas(), task.getFilterTaskSources(),
+                    outputPlugin, task.getOutputSchema(), task.getOutputTaskSource(),
+                    handler);
+            }
+            catch (Exception ex) {
+                try {
+                    handler.setException(ex);
+                } catch (Throwable e) {
+                    e.addSuppressed(ex);
+                    throw e;
+                }
+                // always throw this exception to not start reducers when input fails
+                throw ex;
+            }
+        }
+    }
+
+    public static class EmbulkPartitioningReducer
+            extends Reducer<BufferWritable, PageWritable, NullWritable, NullWritable>
+    {
+        private Context context;
+        private SessionRunner runner;
+        private boolean retryTasks;
+        private AttemptStateUpdateHandler handler;
+        private TransactionalPageOutput output;
+        private boolean failed = false;
+
+        @Override
+        public void setup(final Context context) throws IOException, InterruptedException
+        {
+            this.context = context;
+            this.runner = new SessionRunner(context);
+            this.retryTasks = EmbulkMapReduce.getRetryTasks(context.getConfiguration());
+
+            runner.execSession(new ExecAction<Void>() {
+                public Void run() throws Exception
+                {
+                    runner.readPluginArchive().restoreLoadPathsTo(runner.getScriptingContainer());
+
+                    int taskIndex = context.getTaskAttemptID().getTaskID().getId();
+
+                    ProcessTask task = runner.getMapReduceExecutorTask().getProcessTask();
+                    ExecSession exec = runner.getExecSession();
+                    OutputPlugin outputPlugin = exec.newPlugin(OutputPlugin.class, task.getOutputPluginType());
+
+                    handler = new AttemptStateUpdateHandler(runner,
+                            new AttemptState(context.getTaskAttemptID(), Optional.<Integer>absent(), Optional.of(taskIndex)));
+
+                    output = outputPlugin.open(task.getOutputTaskSource(), task.getExecutorSchema(), taskIndex);
+
+                    handler.started();
+
+                    return null;
+                }
+            });
+        }
+
+        @Override
+        public void reduce(BufferWritable key, final Iterable<PageWritable> values, final Context context)
+                throws IOException, InterruptedException
+        {
+            runner.execSession(new ExecAction<Void>() {
+                public Void run() throws Exception
+                {
+                    process(context, values);
+                    return null;
+                }
+            });
+        }
+
+        private void process(final Context context, Iterable<PageWritable> values) throws IOException, InterruptedException
+        {
+            try {
+                for (PageWritable value : values) {
+                    output.add(value.get());
+                }
+            }
+            catch (Exception ex) {
+                failed = true;
+                try {
+                    handler.setException(ex);
+                } catch (Throwable e) {
+                    e.addSuppressed(ex);
+                    throw e;
+                }
+                if (retryTasks) {
+                    throw ex;
+                }
+            }
+        }
+
+        protected void cleanup(Context context) throws IOException, InterruptedException
+        {
+            runner.execSession(new ExecAction<Void>() {
+                public Void run() throws Exception
+                {
+                    try {
+                        if (!failed) {
+                            output.finish();
+                            TaskReport report = output.commit();
+                            handler.outputCommitted(report);
+                        }
+                    } finally {
+                        output.close();
+                    }
+                    return null;
+                }
+            });
+        }
+    }
+
+    private static class MapperOutputPlugin
+            implements OutputPlugin
+    {
+        private final BufferAllocator bufferAllocator;
+        private final Partitioner partitioner;
+        private final int maxPageBufferCount;
+        private final PartitionedPageOutput output;
+
+        public MapperOutputPlugin(BufferAllocator bufferAllocator,
+                Partitioner partitioner, int maxPageBufferCount,
+                PartitionedPageOutput output)
+        {
+            this.bufferAllocator = bufferAllocator;
+            this.partitioner = partitioner;
+            this.maxPageBufferCount = maxPageBufferCount;
+            this.output = output;
+        }
+
+        @Override
+        public ConfigDiff transaction(ConfigSource config,
+                Schema schema, int taskCount,
+                OutputPlugin.Control control)
+        {
+            // won't be called
+            throw new RuntimeException("");
+        }
+
+        @Override
+        public ConfigDiff resume(TaskSource taskSource,
+                Schema schema, int taskCount,
+                OutputPlugin.Control control)
+        {
+            // won't be called
+            throw new RuntimeException("");
+        }
+
+        @Override
+        public void cleanup(TaskSource taskSource,
+                Schema schema, int taskCount,
+                List<TaskReport> successTaskReports)
+        {
+            // won't be called
+            throw new RuntimeException("");
+        }
+
+        @Override
+        public TransactionalPageOutput open(TaskSource taskSource, final Schema schema, int taskIndex)
+        {
+            return new TransactionalPageOutput() {
+                private final BufferedPagePartitioner bufferedPartitioner = new BufferedPagePartitioner(
+                        bufferAllocator, schema, partitioner, maxPageBufferCount, output);
+                private final PageReader reader = new PageReader(schema);
+
+                public void add(Page page)
+                {
+                    reader.setPage(page);
+                    while (reader.nextRecord()) {
+                        bufferedPartitioner.add(reader);
+                    }
+                }
+
+                public void finish()
+                {
+                    bufferedPartitioner.finish();
+                }
+
+                public void close()
+                {
+                    reader.close();
+                    bufferedPartitioner.close();
+                }
+
+                public void abort()
+                { }
+
+                public TaskReport commit()
+                {
+                    return Exec.newTaskReport();
+                }
+            };
+        }
+    }
+}

--- a/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/EmbulkRecordReader.java
+++ b/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/EmbulkRecordReader.java
@@ -1,0 +1,63 @@
+package org.embulk.executor.mapreduce;
+
+import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.RecordReader;
+
+public class EmbulkRecordReader
+        extends RecordReader<IntWritable, NullWritable>
+{
+    private final int[] taskIndexes;
+    private int offset;
+
+    private final IntWritable currentKey = new IntWritable();
+
+    public EmbulkRecordReader(EmbulkInputSplit split)
+    {
+        this.taskIndexes = split.getTaskIndexes();
+        this.offset = -1;
+    }
+
+    @Override
+    public void initialize(InputSplit split, TaskAttemptContext context)
+    { }
+
+    @Override
+    public boolean nextKeyValue()
+    {
+        offset++;
+        if (taskIndexes.length <= offset) {
+            return false;
+        }
+        currentKey.set(taskIndexes[offset]);
+        return true;
+    }
+
+    @Override
+    public float getProgress()
+    {
+        if (taskIndexes.length == 0) {
+            return (float) 1.0;
+        }
+        return offset / (float) taskIndexes.length;
+    }
+
+    @Override
+    public IntWritable getCurrentKey()
+    {
+        return currentKey;
+    }
+
+    @Override
+    public NullWritable getCurrentValue()
+    {
+        return NullWritable.get();
+    }
+
+    @Override
+    public void close()
+    {
+    }
+}

--- a/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/MapReduceExecutor.java
+++ b/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/MapReduceExecutor.java
@@ -1,0 +1,554 @@
+package org.embulk.executor.mapreduce;
+
+import java.security.PrivilegedAction;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Set;
+import java.util.Map;
+import java.util.LinkedHashSet;
+import java.util.HashMap;
+import java.io.File;
+import java.io.IOException;
+import java.io.EOFException;
+import java.nio.file.FileSystems;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.net.MalformedURLException;
+
+import org.apache.hadoop.security.UserGroupInformation;
+import org.embulk.plugin.PluginType;
+import org.slf4j.Logger;
+import org.joda.time.format.DateTimeFormat;
+import com.google.inject.Inject;
+import com.google.common.base.Optional;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterators;
+import org.jruby.embed.ScriptingContainer;
+import org.apache.hadoop.util.StringUtils;
+import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.FsConstants;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.Cluster;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.JobID;
+import org.apache.hadoop.mapreduce.Counters;
+import org.apache.hadoop.mapreduce.TaskType;
+import org.apache.hadoop.mapreduce.TaskAttemptID;
+import org.apache.hadoop.mapreduce.TaskCompletionEvent;
+import org.apache.hadoop.mapreduce.MRJobConfig;
+import org.apache.hadoop.mapreduce.lib.output.NullOutputFormat;
+import org.embulk.exec.ForSystemConfig;
+import org.embulk.config.ConfigSource;
+import org.embulk.config.TaskReport;
+import org.embulk.config.ConfigException;
+import org.embulk.config.TaskSource;
+import org.embulk.config.ModelManager;
+import org.embulk.spi.Exec;
+import org.embulk.spi.ExecSession;
+import org.embulk.spi.ExecutorPlugin;
+import org.embulk.spi.ProcessTask;
+import org.embulk.spi.ProcessState;
+import org.embulk.spi.TaskState;
+import org.embulk.spi.Schema;
+import org.embulk.spi.time.Timestamp;
+
+public class MapReduceExecutor
+        implements ExecutorPlugin
+{
+    private final Logger log = Exec.getLogger(MapReduceExecutor.class);
+    private final ConfigSource systemConfig;
+    private final ScriptingContainer jruby;
+
+    @Inject
+    public MapReduceExecutor(@ForSystemConfig ConfigSource systemConfig,
+            ScriptingContainer jruby)
+    {
+        this.systemConfig = systemConfig;
+        this.jruby = jruby;
+    }
+
+    @Override
+    public void transaction(ConfigSource config, Schema outputSchema, final int inputTaskCount,
+            ExecutorPlugin.Control control)
+    {
+        final MapReduceExecutorTask task = config.loadConfig(MapReduceExecutorTask.class);
+
+        if (inputTaskCount <= task.getLocalModeInputTasks()) {
+            // if task count is equal or less than local_mode_input_tasks option, those tasks are executed by local executor
+            // TODO if partitioning config is present, they are executed by hadoop local mode
+            log.info("Executing tasks on using local threads");
+            ExecutorPlugin local = Exec.newPlugin(ExecutorPlugin.class, PluginType.LOCAL);
+            local.transaction(config, outputSchema, inputTaskCount, control);
+            return;
+        }
+
+        task.setExecConfig(config);
+
+        final int outputTaskCount;
+        final int reduceTaskCount;
+
+        if (task.getPartitioning().isPresent() && inputTaskCount > 0) { // here can disable partitioning and force set reduceTaskCount and outputTaskCount to 0 if inputTaskCount is 0
+            reduceTaskCount = task.getReducers().or(inputTaskCount);
+            if (reduceTaskCount <= 0) {
+                throw new ConfigException("Reducers must be larger than 1 if partition: is set");
+            }
+            outputTaskCount = reduceTaskCount;
+            ConfigSource partitioningConfig = task.getPartitioning().get();
+            String partitioningType = partitioningConfig.get(String.class, "type");
+            Partitioning partitioning = newPartitioning(partitioningType);
+            TaskSource partitioningTask = partitioning.configure(partitioningConfig, outputSchema, reduceTaskCount);
+            task.setPartitioningType(Optional.of(partitioningType));
+            task.setPartitioningTask(Optional.of(partitioningTask));
+        } else {
+            reduceTaskCount = 0;
+            outputTaskCount = inputTaskCount;
+            task.setPartitioningType(Optional.<String>absent());
+            task.setPartitioningTask(Optional.<TaskSource>absent());
+        }
+
+        control.transaction(outputSchema, outputTaskCount, new ExecutorPlugin.Executor() {
+            public void execute(ProcessTask procTask, ProcessState state)
+            {
+                task.setProcessTask(procTask);
+
+                // hadoop uses ServiceLoader using context classloader to load some implementations
+                try (SetContextClassLoader closeLater = new SetContextClassLoader(MapReduceExecutor.class.getClassLoader())) {
+                    run(task, inputTaskCount, reduceTaskCount, state);
+                }
+            }
+        });
+    }
+
+    static Partitioning newPartitioning(String type)
+    {
+        switch (type) {
+        case "timestamp":
+            return new TimestampPartitioning();
+        default:
+            throw new ConfigException("Unknown partition type '"+type+"'");
+        }
+    }
+
+    private static class TaskReportSet
+    {
+        private Map<Integer, AttemptReport> inputTaskReports = new HashMap<>();
+        private Map<Integer, AttemptReport> outputTaskReports = new HashMap<>();
+
+        private final JobID runningJobId;
+
+        public TaskReportSet(JobID runningJobId)
+        {
+            this.runningJobId = runningJobId;
+        }
+
+        public Collection<AttemptReport> getLatestInputAttemptReports()
+        {
+            return inputTaskReports.values();
+        }
+
+        public Collection<AttemptReport> getLatestOutputAttemptReports()
+        {
+            return outputTaskReports.values();
+        }
+
+        public void update(AttemptReport report)
+        {
+            if (report.getInputTaskIndex().isPresent()) {
+                int taskIndex = report.getInputTaskIndex().get();
+                AttemptReport past = inputTaskReports.get(taskIndex);
+                if (past == null || checkOverwrite(past, report)) {
+                    inputTaskReports.put(taskIndex, report);
+                }
+            }
+            if (report.getOutputTaskIndex().isPresent()) {
+                int taskIndex = report.getOutputTaskIndex().get();
+                AttemptReport past = outputTaskReports.get(taskIndex);
+                if (past == null || checkOverwrite(past, report)) {
+                    outputTaskReports.put(taskIndex, report);
+                }
+            }
+        }
+
+        private boolean checkOverwrite(AttemptReport past, AttemptReport report)
+        {
+            // if already committed successfully, use it
+            if (!past.isOutputCommitted() && report.isOutputCommitted()) {
+                return true;
+            }
+
+            // Here expects that TaskAttemptID.compareTo returns <= 0 if attempt is started later.
+            // However, it returns unexpected result if 2 jobs run on different JobTrackers because
+            // JobID includes start time of a JobTracker with sequence number in the JobTracker
+            // rather than start time of a job. To mitigate this problem, this code assumes that
+            // attempts of the running job is always newer.
+            boolean pastRunning = past.getTaskAttempId().getJobID().equals(runningJobId);
+            boolean reportRunning = report.getTaskAttempId().getJobID().equals(runningJobId);
+            if (!pastRunning && reportRunning) {
+                return true;
+            }
+            return past.getTaskAttempId().compareTo(report.getTaskAttempId()) <= 0;
+        }
+    }
+
+    void run(final MapReduceExecutorTask task,
+            int mapTaskCount, final int reduceTaskCount, final ProcessState state)
+    {
+        final ModelManager modelManager = task.getModelManager();
+
+        final Configuration conf = new Configuration();
+        // don't call conf.setQuietMode(false). Configuraiton has invalid resource names by default
+        for (String path : task.getConfigFiles()) {
+            File file = new File(path);
+            if (!file.isFile()) {
+                throw new ConfigException(String.format("Config file '%s' does not exist", file));
+            }
+            try {
+                // use URL here. Configuration assumes String is a path of a resource in a ClassLoader
+                conf.addResource(file.toURI().toURL());
+            } catch (MalformedURLException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+
+        String uniqueTransactionName = getTransactionUniqueName(Exec.session());
+        final Path stateDir = new Path(new Path(task.getStatePath()), uniqueTransactionName);
+
+        // create a dedicated classloader for this yarn application.
+        // allow task.getConfig to overwrite this parameter
+        conf.set(MRJobConfig.MAPREDUCE_JOB_CLASSLOADER, "true");  // mapreduce.job.classloader
+        conf.set(MRJobConfig.MAPREDUCE_JOB_CLASSLOADER_SYSTEM_CLASSES, "java.,org.apache.hadoop.");  // mapreduce.job.classloader.system.classes
+
+        // extra config
+        for (Map.Entry<String, String> pair : task.getConfig().entrySet()) {
+            conf.set(pair.getKey(), pair.getValue());
+        }
+
+        // framework config
+        EmbulkMapReduce.setSystemConfig(conf, modelManager, systemConfig);
+        EmbulkMapReduce.setExecutorTask(conf, modelManager, task);
+        EmbulkMapReduce.setMapTaskCount(conf, mapTaskCount);  // used by EmbulkInputFormat
+        EmbulkMapReduce.setRetryTasks(conf, task.getRetryTasks());
+        EmbulkMapReduce.setStateDirectoryPath(conf, stateDir);
+
+        // jar files
+        List<Path> jars = collectJars(task.getLibjars(), task.getExcludeJars());
+        conf.set("tmpjars", StringUtils.join(",", jars));
+
+        String remoteUser = conf.get(MRJobConfig.USER_NAME);  // mapreduce.job.user.name
+        if (remoteUser != null) {
+            UserGroupInformation.createRemoteUser(remoteUser).doAs(
+                    new PrivilegedAction<Void>()
+                    {
+                        @Override
+                        public Void run()
+                        {
+                            runJob(task, modelManager, reduceTaskCount, state, stateDir, conf);
+                            return null;
+                        }
+                    }
+            );
+        } else {
+            runJob(task, modelManager, reduceTaskCount, state, stateDir, conf);
+        }
+    }
+
+    void runJob(MapReduceExecutorTask task, ModelManager modelManager,
+            int reduceTaskCount, ProcessState state, Path stateDir, Configuration conf)
+    {
+        Job job;
+        try {
+            job = Job.getInstance(conf);
+        } catch (IOException e) {
+            throw Throwables.propagate(e);
+        }
+        job.setJobName(task.getJobName());
+
+        // archive plugins (also create state dir)
+        PluginArchive archive = new PluginArchive.Builder()
+            .addLoadedRubyGems(jruby)
+            .build();
+        try {
+            EmbulkMapReduce.writePluginArchive(job.getConfiguration(), stateDir, archive, modelManager);
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+
+        job.setInputFormatClass(EmbulkInputFormat.class);
+
+        if (reduceTaskCount > 0) {
+            job.setMapperClass(EmbulkPartitioningMapReduce.EmbulkPartitioningMapper.class);
+            job.setMapOutputKeyClass(BufferWritable.class);
+            job.setMapOutputValueClass(PageWritable.class);
+
+            job.setReducerClass(EmbulkPartitioningMapReduce.EmbulkPartitioningReducer.class);
+
+            job.setNumReduceTasks(reduceTaskCount);
+
+        } else {
+            job.setMapperClass(EmbulkMapReduce.EmbulkMapper.class);
+            job.setMapOutputKeyClass(NullWritable.class);
+            job.setMapOutputValueClass(NullWritable.class);
+
+            job.setReducerClass(EmbulkMapReduce.EmbulkReducer.class);
+
+            job.setNumReduceTasks(0);
+        }
+
+        job.setOutputFormatClass(NullOutputFormat.class);
+        job.setOutputKeyClass(NullWritable.class);
+        job.setOutputValueClass(NullWritable.class);
+
+        try {
+            job.submit();
+            log.info(String.format("Starting job = %s, tracking URL = %s",
+                        job.getJobID(), job.getTrackingURL()));
+
+            TaskReportSet reportSet = new TaskReportSet(job.getJobID());
+
+            int interval = Job.getCompletionPollInterval(job.getConfiguration());
+            while (true) {
+                EmbulkMapReduce.JobStatus status = EmbulkMapReduce.getJobStatus(job);
+                if (status.isComplete()) {
+                    break;
+                }
+                log.info(String.format("map %.1f%% reduce %.1f%%",
+                            status.getMapProgress() * 100, status.getReduceProgress() * 100));
+
+                //if (job.getState() == JobStatus.State.PREP) {
+                //    continue;
+                //}
+                Thread.sleep(interval);
+
+                updateProcessState(job, reportSet, stateDir, state, modelManager, true);
+            }
+
+            EmbulkMapReduce.JobStatus status = EmbulkMapReduce.getJobStatus(job);
+            log.info(String.format("map %.1f%% reduce %.1f%%",
+                        status.getMapProgress() * 100, status.getReduceProgress() * 100));
+            // Here sets inProgress=false to updateProcessState method to tell that race
+            // condition of AttemptReport.readFrom and .writeTo does not happen here.
+            updateProcessState(job, reportSet, stateDir, state, modelManager, false);
+
+            Counters counters = EmbulkMapReduce.getJobCounters(job);
+            if (counters != null) {
+                log.info(counters.toString());
+            }
+        } catch (IOException | InterruptedException | ClassNotFoundException e) {
+            throw Throwables.propagate(e);
+        }
+    }
+
+    private List<Path> collectJars(List<String> extraJars, List<String> excludeJars)
+    {
+        Set<Path> set = new LinkedHashSet<Path>();
+
+        collectURLClassLoaderJars(set, Exec.class.getClassLoader());
+        collectURLClassLoaderJars(set, MapReduceExecutor.class.getClassLoader());
+
+        for (String extraJar : extraJars) {
+            URI uri;
+            try {
+                uri = new URI(extraJar);
+            } catch (URISyntaxException ex) {
+                throw new ConfigException(String.format("Invalid jar path '%s'", extraJar), ex);
+            }
+            if (uri.getScheme() == null) {
+                set.add(localFileToLocalPath(new File(extraJar)));
+            } else {
+                set.add(new Path(uri));
+            }
+        }
+
+        // validate jar files
+        List<Path> uses = new ArrayList<>(set.size());
+        for (Path path : set) {
+            String fileName = path.getName();
+            if (globMatchesWithAnyOf(excludeJars, fileName)) {
+                log.debug("Excluding jar '"+path+"'");
+            }
+            else {
+                uses.add(path);
+            }
+        }
+
+        return uses;
+    }
+
+    private static boolean globMatchesWithAnyOf(List<String> excludeJars, String fileName)
+    {
+        for (String pattern : excludeJars) {
+            if (FileSystems.getDefault().getPathMatcher("glob:"+pattern).matches(java.nio.file.Paths.get(fileName))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void collectURLClassLoaderJars(Set<Path> set, ClassLoader cl)
+    {
+        if (cl instanceof URLClassLoader) {
+            for (URL url : ((URLClassLoader) cl).getURLs()) {
+                File file = new File(url.getPath());
+                if (file.isFile()) {
+                    // TODO log if not found
+                    // TODO debug logging
+                    set.add(localFileToLocalPath(file));
+                }
+            }
+        }
+    }
+
+    private static Path localFileToLocalPath(File file)
+    {
+        Path cwd = new Path(java.nio.file.Paths.get("").toAbsolutePath().toString()).makeQualified(FsConstants.LOCAL_FS_URI, new Path("/"));
+        return new Path(file.toString()).makeQualified(FsConstants.LOCAL_FS_URI, cwd);
+    }
+
+    private static String getTransactionUniqueName(ExecSession session)
+    {
+        // TODO implement Exec.getTransactionUniqueName()
+        Timestamp time = session.getTransactionTime();
+        return DateTimeFormat.forPattern("yyyyMMdd_HHmmss_").withZoneUTC()
+            .print(time.getEpochSecond() * 1000)
+            + String.format("%09d", time.getNano());
+    }
+
+    private void updateProcessState(Job job, TaskReportSet reportSet, Path stateDir,
+            ProcessState state, ModelManager modelManager, boolean inProgress) throws IOException
+    {
+        List<AttemptReport> reports = getAttemptReports(job.getConfiguration(), stateDir, modelManager,
+                inProgress, job.getJobID());
+
+        for (AttemptReport report : reports) {
+            if (report.isAvailable()) {
+                reportSet.update(report);
+            }
+        }
+
+        for (AttemptReport report : reportSet.getLatestInputAttemptReports()) {
+            updateTaskState(state.getInputTaskState(report.getInputTaskIndex().get()), report.getAttemptState(), true);
+        }
+
+        for (AttemptReport report : reportSet.getLatestOutputAttemptReports()) {
+            updateTaskState(state.getOutputTaskState(report.getOutputTaskIndex().get()), report.getAttemptState(), false);
+        }
+    }
+
+    private static void updateTaskState(TaskState state, AttemptState attempt, boolean isInput)
+    {
+        state.start();
+        Optional<TaskReport> taskReport = isInput ? attempt.getInputTaskReport() : attempt.getOutputTaskReport();
+        boolean committed = taskReport.isPresent();
+        if (attempt.getException().isPresent()) {
+            if (!state.isCommitted()) {
+                Exception remoteException;
+                if (attempt.isUserDataException()) {
+                    remoteException = new RemoteTaskFailedDataException(attempt.getException().get());
+                } else {
+                    remoteException = new RemoteTaskFailedException(attempt.getException().get());
+                }
+                state.setException(remoteException);
+            }
+        }
+        if (taskReport.isPresent()) {
+            state.setTaskReport(taskReport.get());
+            state.finish();
+        }
+    }
+
+    private static class AttemptReport
+    {
+        private final TaskAttemptID attemptId;
+        private final AttemptState attemptState;
+        private final IOException unavailableException;
+
+        public AttemptReport(TaskAttemptID attemptId, AttemptState attemptState)
+        {
+            this.attemptId = attemptId;
+            this.attemptState = attemptState;
+            this.unavailableException = null;
+        }
+
+        public AttemptReport(TaskAttemptID attemptId, IOException unavailableException)
+        {
+            this.attemptId = attemptId;
+            this.attemptState = null;
+            this.unavailableException = unavailableException;
+        }
+
+        public boolean isAvailable()
+        {
+            return attemptState != null;
+        }
+
+        public IOException getUnavailableException()
+        {
+            return unavailableException;
+        }
+
+        public Optional<Integer> getInputTaskIndex()
+        {
+            return attemptState == null ? Optional.<Integer>absent() : attemptState.getInputTaskIndex();
+        }
+
+        public Optional<Integer> getOutputTaskIndex()
+        {
+            return attemptState == null ? Optional.<Integer>absent() : attemptState.getOutputTaskIndex();
+        }
+
+        public boolean isInputCommitted()
+        {
+            return attemptState != null && attemptState.getInputTaskReport().isPresent();
+        }
+
+        public boolean isOutputCommitted()
+        {
+            return attemptState != null && attemptState.getOutputTaskReport().isPresent();
+        }
+
+        public TaskAttemptID getTaskAttempId()
+        {
+            return attemptId;
+        }
+
+        public AttemptState getAttemptState()
+        {
+            return attemptState;
+        }
+    }
+
+    private static List<AttemptReport> getAttemptReports(Configuration config,
+            Path stateDir, ModelManager modelManager,
+            boolean jobIsRunning, JobID runningJobId) throws IOException
+    {
+        ImmutableList.Builder<AttemptReport> builder = ImmutableList.builder();
+        for (TaskAttemptID aid : EmbulkMapReduce.listAttempts(config, stateDir)) {
+            boolean concurrentWriteIsPossible = aid.getJobID().equals(runningJobId) && jobIsRunning;
+            try {
+                AttemptState state = EmbulkMapReduce.readAttemptStateFile(config,
+                        stateDir, aid, modelManager, concurrentWriteIsPossible);
+                builder.add(new AttemptReport(aid, state));
+            } catch (IOException ex) {
+                // See comments on readAttemptStateFile for the possible error causes.
+                if (!concurrentWriteIsPossible) {
+                    if (!(ex instanceof EOFException)) {
+                        // f) HDFS is broken. This is critical problem which should throw an exception
+                        throw new RuntimeException(ex);
+                    }
+                    // HDFS is working but file is corrupted. It is always possible that the directly
+                    // contains corrupted file created by past attempts of retried task or job. Ignore it.
+                }
+                // if concurrentWriteIsPossible, there're no ways to tell the cause. Ignore it.
+                builder.add(new AttemptReport(aid, ex));
+            }
+        }
+        return builder.build();
+    }
+}

--- a/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/MapReduceExecutorTask.java
+++ b/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/MapReduceExecutorTask.java
@@ -1,0 +1,75 @@
+package org.embulk.executor.mapreduce;
+
+import java.util.List;
+import java.util.Map;
+import com.google.common.base.Optional;
+import org.embulk.config.Config;
+import org.embulk.config.ConfigInject;
+import org.embulk.config.ConfigDefault;
+import org.embulk.config.ConfigSource;
+import org.embulk.config.Task;
+import org.embulk.config.TaskSource;
+import org.embulk.config.ModelManager;
+import org.embulk.spi.ProcessTask;
+
+import javax.validation.constraints.Min;
+
+public interface MapReduceExecutorTask
+        extends Task
+{
+    @Config("job_name")
+    @ConfigDefault("\"embulk\"")
+    public String getJobName();
+
+    @Config("config_files")
+    @ConfigDefault("[]")
+    public List<String> getConfigFiles();
+
+    @Config("config")
+    @ConfigDefault("{}")
+    public Map<String, String> getConfig();
+
+    @Config("libjars")
+    @ConfigDefault("[]")
+    public List<String> getLibjars();
+
+    @Config("exclude_jars")
+    @ConfigDefault("[]")
+    public List<String> getExcludeJars();
+
+    @Config("state_path")
+    @ConfigDefault("\"/tmp/embulk\"")
+    public String getStatePath();
+
+    @Config("reducers")
+    @ConfigDefault("null")
+    public Optional<Integer> getReducers();
+
+    @Config("retry_tasks")
+    @ConfigDefault("false")
+    public boolean getRetryTasks();
+
+    @Config("partitioning")
+    @ConfigDefault("null")
+    public Optional<ConfigSource> getPartitioning();
+
+    @Config("local_mode_input_tasks")
+    @ConfigDefault("0")
+    @Min(0)
+    public Integer getLocalModeInputTasks();
+
+    @ConfigInject
+    public ModelManager getModelManager();
+
+    public ConfigSource getExecConfig();
+    public void setExecConfig(ConfigSource execConfig);
+
+    public ProcessTask getProcessTask();
+    public void setProcessTask(ProcessTask task);
+
+    public Optional<String> getPartitioningType();
+    public void setPartitioningType(Optional<String> partitioningType);
+
+    public Optional<TaskSource> getPartitioningTask();
+    public void setPartitioningTask(Optional<TaskSource> partitioningTask);
+}

--- a/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/PageWritable.java
+++ b/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/PageWritable.java
@@ -1,0 +1,107 @@
+package org.embulk.executor.mapreduce;
+
+import java.io.IOException;
+import java.io.DataOutput;
+import java.io.DataInput;
+import java.util.List;
+import java.util.ArrayList;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.io.WritableUtils;
+import org.apache.hadoop.io.DataOutputOutputStream;
+import org.msgpack.value.Value;
+import org.msgpack.value.ImmutableValue;
+import org.msgpack.core.MessagePack;
+import org.msgpack.core.MessageBufferPacker;
+import org.msgpack.core.MessageUnpacker;
+import org.msgpack.core.buffer.MessageBuffer;
+import org.embulk.spi.Buffer;
+import org.embulk.spi.Page;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class PageWritable
+        implements Writable
+{
+    private Page page;
+
+    public PageWritable() { }
+
+    public void set(Page page)
+    {
+        this.page = page;
+    }
+
+    public Page get()
+    {
+        return page;
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException
+    {
+        Buffer buffer = page.buffer();
+        out.writeInt(buffer.limit());
+        out.write(buffer.array(), buffer.offset(), buffer.limit());
+
+        List<String> stringReferences = page.getStringReferences();
+        WritableUtils.writeVInt(out, stringReferences.size());
+        for (String s : stringReferences) {
+            out.writeUTF(s);
+        }
+
+        List<ImmutableValue> valueReferences = page.getValueReferences();
+        WritableUtils.writeVInt(out, valueReferences.size());
+        for (Value value : valueReferences) {
+            MessageBufferPacker packer = MessagePack.newDefaultBufferPacker();  // TODO reuse allocated buffer
+            value.writeTo(packer);
+            List<MessageBuffer> buffers = packer.toBufferList();
+            int size = 0;
+            for (MessageBuffer b : buffers) {
+                size += b.size();
+            }
+            WritableUtils.writeVInt(out, size);
+            for (MessageBuffer b : buffers) {
+                out.write(b.array(), b.arrayOffset(), b.size());
+            }
+        }
+    }
+
+    @Override
+    public void readFields(DataInput in) throws IOException
+    {
+        int bufferSize = in.readInt();
+        byte[] bytes = new byte[bufferSize];  // TODO usa buffer allocator?
+        in.readFully(bytes, 0, bufferSize);
+        Buffer buffer = Buffer.wrap(bytes);
+
+        int stringCount = WritableUtils.readVInt(in);
+        List<String> strings = new ArrayList<>(stringCount);
+        for (int i=0; i < stringCount; i++) {
+            strings.add(in.readUTF());
+        }
+
+        int valueCount = WritableUtils.readVInt(in);
+        List<ImmutableValue> values = new ArrayList<>(valueCount);
+        byte[] b = new byte[32 * 1024];
+        for (int i=0; i < valueCount; i++) {
+            int size = WritableUtils.readVInt(in);
+            if (b.length < size) {
+                int ns = b.length;
+                while (ns < size) {
+                    ns *= 2;
+                }
+                b = new byte[ns];
+            }
+            in.readFully(b, 0, size);
+            MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(b, 0, size);
+            values.add(unpacker.unpackValue());
+        }
+
+        Page newPage = Page.wrap(buffer);
+        newPage.setStringReferences(strings);
+        newPage.setValueReferences(values);
+        if (page != null) {
+            page.release();
+        }
+        page = newPage;
+    }
+}

--- a/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/PartitionKey.java
+++ b/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/PartitionKey.java
@@ -1,0 +1,11 @@
+package org.embulk.executor.mapreduce;
+
+import org.embulk.spi.Buffer;
+
+public interface PartitionKey
+        extends Cloneable
+{
+    public void dump(Buffer buffer);
+
+    public PartitionKey clone();
+}

--- a/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/Partitioner.java
+++ b/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/Partitioner.java
@@ -1,0 +1,11 @@
+package org.embulk.executor.mapreduce;
+
+import org.embulk.spi.Buffer;
+import org.embulk.spi.PageReader;
+
+public interface Partitioner
+{
+    public Buffer newKeyBuffer();
+
+    public PartitionKey updateKey(PageReader record);
+}

--- a/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/Partitioning.java
+++ b/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/Partitioning.java
@@ -1,0 +1,12 @@
+package org.embulk.executor.mapreduce;
+
+import org.embulk.config.ConfigSource;
+import org.embulk.config.TaskSource;
+import org.embulk.spi.Schema;
+
+public interface Partitioning
+{
+    public TaskSource configure(ConfigSource config, Schema schema, int outputTaskCount);
+
+    public Partitioner newPartitioner(TaskSource taskSource);
+}

--- a/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/PluginArchive.java
+++ b/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/PluginArchive.java
@@ -1,0 +1,189 @@
+package org.embulk.executor.mapreduce;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.io.File;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Files;
+import java.nio.file.DirectoryStream;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.NotDirectoryException;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import java.util.zip.ZipInputStream;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.ByteStreams;
+import org.jruby.embed.ScriptingContainer;
+import org.jruby.embed.InvokeFailedException;
+
+public class PluginArchive
+{
+    public static class GemSpec
+    {
+        private final String name;
+        private final List<String> requirePaths;
+
+        @JsonCreator
+        public GemSpec(
+                @JsonProperty("name") String name,
+                @JsonProperty("requirePaths") List<String> requirePaths)
+        {
+            this.name = name;
+            this.requirePaths = requirePaths;
+        }
+
+        @JsonProperty("name")
+        public String getName()
+        {
+            return name;
+        }
+
+        @JsonProperty("requirePaths")
+        public List<String> getRequirePaths()
+        {
+            return requirePaths;
+        }
+    }
+
+    private static class LocalGem
+            extends GemSpec
+    {
+        private final File localPath;
+
+        public LocalGem(File localPath, String name, List<String> requirePaths)
+        {
+            super(name, requirePaths);
+            this.localPath = localPath;
+        }
+
+        public File getLocalPath()
+        {
+            return localPath;
+        }
+    }
+
+    public static class Builder
+    {
+        private final ImmutableList.Builder<LocalGem> localGems = ImmutableList.builder();
+
+        @SuppressWarnings("unchecked")
+        public Builder addLoadedRubyGems(ScriptingContainer jruby)
+        {
+            List<List<String>> tuples = (List<List<String>>) jruby.runScriptlet("Gem.loaded_specs.map {|k,v| [k, v.full_gem_path, v.require_paths].flatten }");
+            for (List<String> tuple : tuples) {
+                String name = tuple.remove(0);
+                String fullGemPath = tuple.remove(0);
+                List<String> requirePaths = ImmutableList.copyOf(tuple);
+                addSpec(new File(fullGemPath), name, requirePaths);
+            }
+            return this;
+        }
+
+        public Builder addSpec(File localPath, String name, List<String> requirePaths)
+        {
+            localGems.add(new LocalGem(localPath, name, requirePaths));
+            return this;
+        }
+
+        public PluginArchive build()
+        {
+            return new PluginArchive(localGems.build());
+        }
+    }
+
+    private final List<LocalGem> localGems;
+
+    private PluginArchive(List<LocalGem> localGems)
+    {
+        this.localGems = localGems;
+    }
+
+    @SuppressWarnings("unchecked")
+    public void restoreLoadPathsTo(ScriptingContainer jruby)
+    {
+        List<String> loadPaths = (List<String>) jruby.runScriptlet("$LOAD_PATH");
+        for (LocalGem localGem : localGems) {
+            Path localGemPath = localGem.getLocalPath().toPath();
+            for (String requirePath : localGem.getRequirePaths()) {
+                loadPaths.add(localGemPath.resolve(requirePath).toString());
+            }
+        }
+        jruby.setLoadPaths(loadPaths);
+    }
+
+    public List<GemSpec> dump(OutputStream out)
+        throws IOException
+    {
+        ImmutableList.Builder<GemSpec> builder = ImmutableList.builder();
+        try (ZipOutputStream zip = new ZipOutputStream(out)) {
+            for (LocalGem localGem : localGems) {
+                zipDirectory(zip, localGem.getLocalPath().toPath(), localGem.getName() + "/");
+                builder.add(new GemSpec(localGem.getName(), localGem.getRequirePaths()));
+            }
+        }
+        return builder.build();
+    }
+
+    private static void zipDirectory(ZipOutputStream zip, Path directory, String name)
+        throws IOException
+    {
+        try (DirectoryStream<Path> dirStream = Files.newDirectoryStream(directory)) {
+            for (Path path : dirStream) {
+                if (Files.isDirectory(path)) {
+                    zipDirectory(zip, path, name + path.getFileName() + "/");
+                } else {
+                    zip.putNextEntry(new ZipEntry(name + path.getFileName()));
+                    try (InputStream in = Files.newInputStream(path)) {
+                        ByteStreams.copy(in, zip);
+                    }
+                    zip.closeEntry();
+                }
+            }
+        } catch (NoSuchFileException | NotDirectoryException ex) {
+            // ignore
+        }
+    }
+
+    public static PluginArchive load(File localDirectory, List<GemSpec> gemSpecs,
+            InputStream in) throws IOException
+    {
+        try (ZipInputStream zip = new ZipInputStream(in)) {
+            unzipDirectory(zip, localDirectory.toPath());
+        }
+
+        ImmutableList.Builder<LocalGem> builder = ImmutableList.builder();
+        for (GemSpec gemSpec : gemSpecs) {
+            builder.add(new LocalGem(
+                        new File(localDirectory, gemSpec.getName()),
+                        gemSpec.getName(),
+                        gemSpec.getRequirePaths()));
+        }
+        return new PluginArchive(builder.build());
+    }
+
+    private static void unzipDirectory(ZipInputStream zip, Path directory)
+        throws IOException
+    {
+        while (true) {
+            ZipEntry entry = zip.getNextEntry();
+            if (entry == null) {
+                break;
+            }
+            Path path = directory.resolve(entry.getName());
+            if (entry.getName().endsWith("/")) {
+                Files.createDirectories(path);
+            } else {
+                Files.createDirectories(path.getParent());
+                try (OutputStream out = Files.newOutputStream(path)) {
+                    ByteStreams.copy(zip, out);
+                }
+            }
+        }
+    }
+}

--- a/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/RemoteTaskFailedDataException.java
+++ b/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/RemoteTaskFailedDataException.java
@@ -1,0 +1,12 @@
+package org.embulk.executor.mapreduce;
+
+import org.embulk.spi.DataException;
+
+public class RemoteTaskFailedDataException
+        extends DataException
+{
+    public RemoteTaskFailedDataException(String message)
+    {
+        super(message);
+    }
+}

--- a/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/RemoteTaskFailedException.java
+++ b/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/RemoteTaskFailedException.java
@@ -1,0 +1,10 @@
+package org.embulk.executor.mapreduce;
+
+public class RemoteTaskFailedException
+        extends RuntimeException
+{
+    public RemoteTaskFailedException(String message)
+    {
+        super(message);
+    }
+}

--- a/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/SetContextClassLoader.java
+++ b/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/SetContextClassLoader.java
@@ -1,0 +1,19 @@
+package org.embulk.executor.mapreduce;
+
+public class SetContextClassLoader
+        implements AutoCloseable
+{
+    private final ClassLoader original;
+
+    public SetContextClassLoader(ClassLoader classLoader)
+    {
+        this.original = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(classLoader);
+    }
+
+    @Override
+    public void close()
+    {
+        Thread.currentThread().setContextClassLoader(original);
+    }
+}

--- a/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/TimestampPartitioning.java
+++ b/embulk-executor-mapreduce_2_7/src/main/java/org/embulk/executor/mapreduce/TimestampPartitioning.java
@@ -1,0 +1,330 @@
+package org.embulk.executor.mapreduce;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.Max;
+import com.google.common.annotations.VisibleForTesting;
+import org.joda.time.DateTimeZone;
+import com.google.common.base.Optional;
+import org.embulk.config.Config;
+import org.embulk.config.ConfigDefault;
+import org.embulk.config.ConfigSource;
+import org.embulk.config.ConfigException;
+import org.embulk.config.Task;
+import org.embulk.config.TaskSource;
+import org.embulk.spi.time.Timestamp;
+import org.embulk.spi.type.TimestampType;
+import org.embulk.spi.type.LongType;
+import org.embulk.spi.Column;
+import org.embulk.spi.PageReader;
+import org.embulk.spi.Schema;
+import org.embulk.spi.Buffer;
+
+public class TimestampPartitioning
+        implements Partitioning
+{
+    public interface PartitioningTask
+            extends Task
+    {
+        @Config("column")
+        public String getColumn();
+
+        @Config("unit")
+        public String getUnit();
+
+        @Config("timezone")
+        @ConfigDefault("\"UTC\"")
+        public DateTimeZone getTimeZone();
+
+        @Config("unix_timestamp_unit")
+        @ConfigDefault("\"sec\"")
+        public String getUnixTimestamp();
+
+        @Config("map_side_partition_split")
+        @ConfigDefault("1")
+        @Min(1)
+        @Max(65535)  // TimestampPartitioning.LongPartitionKey encodes split number in 16-bit buffer
+        public int getMapSidePartitionSplit();
+
+        public Column getTargetColumn();
+        public void setTargetColumn(Column column);
+    }
+
+    @VisibleForTesting
+    static enum Unit
+    {
+        HOUR(60*60),
+        DAY(24*60*60);
+        //WEEK
+        //MONTH,
+        //YEAR;
+
+        private final int unit;
+
+        private Unit(int unit)
+        {
+            this.unit = unit;
+        }
+
+        public long utcPartition(long seconds)
+        {
+            return seconds / unit;
+        }
+
+        public static Unit of(String s)
+        {
+            switch (s) {
+            case "hour": return HOUR;
+            case "day": return DAY;
+            //case "week": return WEEK;
+            //case "month": return MONTH;
+            //case "year": return YEAR;
+            default:
+                throw new ConfigException(
+                        String.format("Unknown unit '%s'. Supported units are hour and day", s));
+            }
+        }
+    }
+
+    @VisibleForTesting
+    static enum UnixTimestampUnit
+    {
+        SEC(1),
+        MILLI(1000),
+        MICRO(1000000),
+        NANO(1000000000);
+
+        private final int unit;
+
+        private UnixTimestampUnit(int unit)
+        {
+            this.unit = unit;
+        }
+
+        public long toSeconds(long v)
+        {
+            return v / unit;
+        }
+
+        public static UnixTimestampUnit of(String s)
+        {
+            switch (s) {
+            case "sec": return SEC;
+            case "milli": return MILLI;
+            case "micro": return MICRO;
+            case "nano": return NANO;
+            default:
+                throw new ConfigException(
+                        String.format("Unknown unix_timestamp_unit '%s'. Supported units are sec, milli, micro, and nano", s));
+            }
+        }
+    }
+
+    @Override
+    public TaskSource configure(ConfigSource config, Schema schema, int outputTaskCount)
+    {
+        PartitioningTask task = config.loadConfig(PartitioningTask.class);
+        Column column = findColumnByName(schema, task.getColumn());
+
+        if (!task.getTimeZone().equals(DateTimeZone.UTC)) {
+            // TODO
+            throw new ConfigException("Timestamp partitioner supports only UTC time zone for now");
+        }
+
+        // validate unit
+        Unit.of(task.getUnit());
+
+        // validate type
+        if (column.getType() instanceof TimestampType) {
+            // ok
+        } else if (column.getType() instanceof LongType) {
+            // validate unix_timestamp_unit
+            UnixTimestampUnit.of(task.getUnixTimestamp());
+        } else {
+            throw new ConfigException(
+                    String.format("Partitioning column '%s' must be timestamp or long but got '%s'", column.getName(), column.getType()));
+        }
+
+        task.setTargetColumn(column);
+
+        return task.dump();
+    }
+
+    private static Column findColumnByName(Schema schema, String columnName)
+    {
+        for (Column column : schema.getColumns()) {
+            if (column.getName().equals(columnName)) {
+                return column;
+            }
+        }
+        throw new ConfigException(
+                String.format("Column '%s' is not found in schema", columnName));
+    }
+
+    @Override
+    public Partitioner newPartitioner(TaskSource taskSource)
+    {
+        PartitioningTask task = taskSource.loadTask(PartitioningTask.class);
+
+        Column column = task.getTargetColumn();
+        if (column.getType() instanceof TimestampType) {
+            return new TimestampPartitioner(
+                    column,
+                    Unit.of(task.getUnit()),
+                    task.getMapSidePartitionSplit());
+        }
+        else if (column.getType() instanceof LongType) {
+            return new LongUnixTimestampPartitioner(
+                    column,
+                    Unit.of(task.getUnit()),
+                    task.getMapSidePartitionSplit(),
+                    UnixTimestampUnit.of(task.getUnixTimestamp()));
+        }
+        else {
+            throw new AssertionError();
+        }
+    }
+
+    private static class LongPartitionKey
+            implements PartitionKey
+    {
+        public static Buffer newKeyBuffer()
+        {
+            Buffer buffer = Buffer.allocate(8);
+            buffer.limit(8);
+            return buffer;
+        }
+
+        private long value;
+
+        public LongPartitionKey()
+        { }
+
+        private LongPartitionKey(long value)
+        {
+            this.value = value;
+        }
+
+        public void set(long value)
+        {
+            this.value = value;
+        }
+
+        @Override
+        public void dump(Buffer buffer)
+        {
+            // TODO optimize
+            buffer.array()[0] = (byte) (((int) (value >>>  0)) & 0xff);
+            buffer.array()[1] = (byte) (((int) (value >>>  4)) & 0xff);
+            buffer.array()[2] = (byte) (((int) (value >>>  8)) & 0xff);
+            buffer.array()[3] = (byte) (((int) (value >>> 12)) & 0xff);
+            buffer.array()[4] = (byte) (((int) (value >>> 16)) & 0xff);
+            buffer.array()[5] = (byte) (((int) (value >>> 20)) & 0xff);
+            buffer.array()[6] = (byte) (((int) (value >>> 24)) & 0xff);
+            buffer.array()[7] = (byte) (((int) (value >>> 28)) & 0xff);
+        }
+
+        @Override
+        public LongPartitionKey clone()
+        {
+            return new LongPartitionKey(value);
+        }
+
+        @Override
+        public boolean equals(Object other)
+        {
+            if (!(other instanceof LongPartitionKey)) {
+                return false;
+            }
+            LongPartitionKey o = (LongPartitionKey) other;
+            return value == o.value;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return (int) (value ^ (value >>> 32));
+        }
+    }
+
+    private static abstract class AbstractTimestampPartitioner
+            implements Partitioner
+    {
+        protected final Column column;
+        protected final Unit unit;
+        protected final int mapSidePartitionSplit;
+        private final LongPartitionKey key;
+        private long roundRobin;
+
+        public AbstractTimestampPartitioner(Column column, Unit unit, int mapSidePartitionSplit)
+        {
+            this.column = column;
+            this.unit = unit;
+            this.mapSidePartitionSplit = mapSidePartitionSplit;
+            this.key = new LongPartitionKey();
+            this.roundRobin = 0;
+        }
+
+        @Override
+        public Buffer newKeyBuffer()
+        {
+            return LongPartitionKey.newKeyBuffer();
+        }
+
+        protected LongPartitionKey updateKey(long v)
+        {
+            // ((v << 16) | (roundRobin % mapSidePartitionSplit)) is used to distribute a large partition to
+            // multiple reducers. But this algorithm is not ideal under following scenario:
+            //
+            //   * input data is in 2 hour (hour-0 and hour-1), and partitioning unit is hour.
+            //   * there're 4 reducers.
+            //   * with mapSidePartitionSplit = 1, hadoop uses 3 reducers because
+            //     hour-0 is partitoned to reducer 0 (v + 0) and 1 (v + 1)
+            //     hour-1 is partitoned to reducer 1 (v + 0) and 2 (v + 1)
+            //
+            // So, here needs further optimization to distribute load of the reducers.
+            //
+            key.set((v << 16) | (roundRobin % mapSidePartitionSplit));
+            roundRobin++;
+            return key;
+        }
+    }
+
+    @VisibleForTesting
+    static class TimestampPartitioner
+            extends AbstractTimestampPartitioner
+    {
+        public TimestampPartitioner(Column column, Unit unit, int mapSidePartitionSplit)
+        {
+            super(column, unit, mapSidePartitionSplit);
+        }
+
+        @Override
+        public PartitionKey updateKey(PageReader record)
+        {
+            Timestamp v = record.getTimestamp(column);
+            return super.updateKey(unit.utcPartition(v.getEpochSecond()));
+        }
+    }
+
+    @VisibleForTesting
+    static class LongUnixTimestampPartitioner
+            extends AbstractTimestampPartitioner
+    {
+        private final UnixTimestampUnit unixTimestampUnit;
+
+        public LongUnixTimestampPartitioner(Column column, Unit unit,
+                int mapSidePartitionSplit,
+                UnixTimestampUnit unixTimestampUnit)
+        {
+            super(column, unit, mapSidePartitionSplit);
+            this.unixTimestampUnit = unixTimestampUnit;
+        }
+
+        @Override
+        public PartitionKey updateKey(PageReader record)
+        {
+            long v = record.getLong(column);
+            return super.updateKey(unit.utcPartition(unixTimestampUnit.toSeconds(v)));
+        }
+    }
+}

--- a/embulk-executor-mapreduce_2_7/src/test/java/org/embulk/executor/mapreduce/MapReduceExecutorTestRuntime.java
+++ b/embulk-executor-mapreduce_2_7/src/test/java/org/embulk/executor/mapreduce/MapReduceExecutorTestRuntime.java
@@ -1,0 +1,130 @@
+package org.embulk.executor.mapreduce;
+
+import java.util.Random;
+
+import com.google.inject.util.Modules;
+import org.embulk.GuiceBinder;
+import org.embulk.RandomManager;
+import org.embulk.TestPluginSourceModule;
+import org.embulk.TestUtilityModule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import com.google.inject.Injector;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import org.embulk.config.ConfigSource;
+import org.embulk.config.DataSourceImpl;
+import org.embulk.config.ModelManager;
+import org.embulk.exec.SystemConfigModule;
+import org.embulk.exec.ExecModule;
+import org.embulk.exec.ExtensionServiceLoaderModule;
+import org.embulk.plugin.BuiltinPluginSourceModule;
+import org.embulk.jruby.JRubyScriptingModule;
+import org.embulk.spi.BufferAllocator;
+import org.embulk.spi.Exec;
+import org.embulk.spi.ExecAction;
+import org.embulk.spi.ExecSession;
+
+// TODO This class should be merged into EmbulkTestRuntime class. Because EmbulkTestRuntime doesn't have module overriding feature.
+public class MapReduceExecutorTestRuntime
+        extends GuiceBinder
+{
+    private static ConfigSource getSystemConfig()
+    {
+        // TODO set some default values
+        return new DataSourceImpl(null);
+    }
+
+    public static class TestRuntimeModule
+            implements Module
+    {
+        @Override
+        public void configure(Binder binder)
+        {
+            ConfigSource systemConfig = getSystemConfig();
+
+            new SystemConfigModule(systemConfig).configure(binder);
+            new ExecModule().configure(binder);
+            new ExtensionServiceLoaderModule(systemConfig).configure(binder);
+            new BuiltinPluginSourceModule().configure(binder);
+            new JRubyScriptingModule(systemConfig).configure(binder);
+            new TestUtilityModule().configure(binder);
+            new TestPluginSourceModule().configure(binder);
+
+        }
+    }
+
+    private ExecSession exec;
+
+    public MapReduceExecutorTestRuntime()
+    {
+        super(Modules.override(new TestRuntimeModule()).with(new Module() {
+            @Override
+            public void configure(Binder binder)
+            {
+                new TestMapReduceExecutor.ExecutorPluginApplyModule().configure(binder);
+                new TestMapReduceExecutor.LoggerOverrideModule().configure(binder);
+            }
+        }));
+        Injector injector = getInjector();
+        ConfigSource execConfig = new DataSourceImpl(injector.getInstance(ModelManager.class));
+        this.exec = ExecSession.builder(injector).fromExecConfig(execConfig).build();
+    }
+
+    public ExecSession getExec()
+    {
+        return exec;
+    }
+
+    public BufferAllocator getBufferAllocator()
+    {
+        return getInstance(BufferAllocator.class);
+    }
+
+    public ModelManager getModelManager()
+    {
+        return getInstance(ModelManager.class);
+    }
+
+    public Random getRandom()
+    {
+        return getInstance(RandomManager.class).getRandom();
+    }
+
+    @Override
+    public Statement apply(Statement base, Description description)
+    {
+        final Statement superStatement = MapReduceExecutorTestRuntime.super.apply(base, description);
+        return new Statement() {
+            public void evaluate() throws Throwable
+            {
+                try {
+                    Exec.doWith(exec, new ExecAction<Void>() {
+                        public Void run()
+                        {
+                            try {
+                                superStatement.evaluate();
+                            } catch (Throwable ex) {
+                                throw new RuntimeExecutionException(ex);
+                            }
+                            return null;
+                        }
+                    });
+                } catch (RuntimeException ex) {
+                    throw ex.getCause();
+                } finally {
+                    exec.cleanup();
+                }
+            }
+        };
+    }
+
+    private static class RuntimeExecutionException
+            extends RuntimeException
+    {
+        public RuntimeExecutionException(Throwable cause)
+        {
+            super(cause);
+        }
+    }
+}

--- a/embulk-executor-mapreduce_2_7/src/test/java/org/embulk/executor/mapreduce/TestAttemptState.java
+++ b/embulk-executor-mapreduce_2_7/src/test/java/org/embulk/executor/mapreduce/TestAttemptState.java
@@ -1,0 +1,58 @@
+package org.embulk.executor.mapreduce;
+
+import com.google.common.base.Optional;
+
+import org.apache.hadoop.mapreduce.TaskAttemptID;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestAttemptState
+{
+    @Rule
+    public MapReduceExecutorTestRuntime runtime = new MapReduceExecutorTestRuntime();
+
+    @Test
+    public void readAndWrite()
+            throws IOException {
+        TaskAttemptID attemptId = TaskAttemptID.forName("attempt_200707121733_0003_m_000005_0");
+        int inputTaskIndex = 1;
+        int outputTaskIndex = 2;
+        Exception ex = new Exception();
+
+        AttemptState attemptState = new AttemptState(attemptId, Optional.of(inputTaskIndex), Optional.of(outputTaskIndex));
+        attemptState.setException(ex);
+        attemptState.setInputTaskReport(runtime.getExec().newTaskReport());
+        attemptState.setOutputTaskReport(runtime.getExec().newTaskReport());
+
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            attemptState.writeTo(out, runtime.getModelManager());
+
+            try (ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray())) {
+                assertAttemptStateEquals(attemptState, AttemptState.readFrom(in, runtime.getModelManager()));
+            }
+        }
+    }
+
+    private static void assertAttemptStateEquals(AttemptState s1, AttemptState s2)
+    {
+        assertEquals(s1.getAttemptId(), s2.getAttemptId());
+        assertEquals(s1.getInputTaskIndex(), s2.getInputTaskIndex());
+        assertEquals(s1.getOutputTaskIndex(), s2.getOutputTaskIndex());
+        assertEquals(s1.getException(), s2.getException());
+        assertEquals(s1.getInputTaskReport(), s2.getInputTaskReport());
+        assertEquals(s1.getOutputTaskReport(), s2.getOutputTaskReport());
+    }
+
+    @Test
+    public void throwEOFIfInvalidJsonString()
+            throws IOException {
+        String json = "{\"key\":\"va";
+        // TODO
+    }
+}

--- a/embulk-executor-mapreduce_2_7/src/test/java/org/embulk/executor/mapreduce/TestEmbulkInputFormat.java
+++ b/embulk-executor-mapreduce_2_7/src/test/java/org/embulk/executor/mapreduce/TestEmbulkInputFormat.java
@@ -1,0 +1,54 @@
+package org.embulk.executor.mapreduce;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.JobID;
+import org.apache.hadoop.mapreduce.task.JobContextImpl;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestEmbulkInputFormat
+{
+    @Rule
+    public MapReduceExecutorTestRuntime runtime = new MapReduceExecutorTestRuntime();
+
+    private Configuration conf;
+    private EmbulkInputFormat format;
+
+    @Before
+    public void createResources()
+    {
+        conf = new Configuration();
+        format = new EmbulkInputFormat();
+    }
+
+    @Test
+    public void getSplits()
+            throws Exception
+    {
+        checkNumOfSplits(0);
+
+        for (int i = 0; i < 10; i++) {
+
+            int split = runtime.getRandom().nextInt(10000);
+            checkNumOfSplits(split);
+        }
+    }
+
+    private void checkNumOfSplits(int split)
+            throws Exception
+    {
+        conf.set("embulk.mapreduce.taskCount", Integer.toString(split));
+        JobContext jobContext = newJobContext(conf);
+        assertEquals(split, format.getSplits(jobContext).size());
+    }
+
+    private JobContext newJobContext(Configuration conf)
+    {
+        JobID jobID = new JobID("test", runtime.getRandom().nextInt());
+        return new JobContextImpl(conf, jobID);
+    }
+}

--- a/embulk-executor-mapreduce_2_7/src/test/java/org/embulk/executor/mapreduce/TestEmbulkInputSplit.java
+++ b/embulk-executor-mapreduce_2_7/src/test/java/org/embulk/executor/mapreduce/TestEmbulkInputSplit.java
@@ -1,0 +1,46 @@
+package org.embulk.executor.mapreduce;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class TestEmbulkInputSplit
+{
+    @Test
+    public void readAndWrite()
+            throws IOException
+    {
+        readAndWrite(new EmbulkInputSplit());
+        readAndWrite(new EmbulkInputSplit(new int[] {0, 1, 2, 3}));
+    }
+
+    private void readAndWrite(EmbulkInputSplit is) throws IOException
+    {
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            try (DataOutputStream dout = new DataOutputStream(out)) {
+                is.write(dout);
+                dout.flush();
+
+                try (DataInputStream in = new DataInputStream(new ByteArrayInputStream(out.toByteArray()))) {
+                    EmbulkInputSplit newIs = new EmbulkInputSplit();
+                    newIs.readFields(in);
+                    assertEmbulkInputSplitEquals(is, newIs);
+                }
+            }
+        }
+    }
+
+    private static void assertEmbulkInputSplitEquals(EmbulkInputSplit is1, EmbulkInputSplit is2)
+    {
+        assertArrayEquals(is1.getTaskIndexes(), is2.getTaskIndexes());
+        assertEquals(is1.getLength(), is2.getLength());
+        assertArrayEquals(is1.getLocations(), is2.getLocations());
+    }
+}

--- a/embulk-executor-mapreduce_2_7/src/test/java/org/embulk/executor/mapreduce/TestEmbulkRecordReader.java
+++ b/embulk-executor-mapreduce_2_7/src/test/java/org/embulk/executor/mapreduce/TestEmbulkRecordReader.java
@@ -1,0 +1,25 @@
+package org.embulk.executor.mapreduce;
+
+import org.apache.hadoop.io.NullWritable;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class TestEmbulkRecordReader
+{
+    @Test
+    public void simpleTest()
+    {
+        int[] taskIndexes = new int[] {0, 1, 4, 6, 7};
+        try (EmbulkRecordReader r = new EmbulkRecordReader(new EmbulkInputSplit(taskIndexes))) {
+            int i = 0;
+            while (r.nextKeyValue()) {
+                assertEquals(taskIndexes[i], r.getCurrentKey().get());
+                assertTrue(r.getCurrentValue() instanceof NullWritable);
+                i++;
+            }
+            assertEquals(taskIndexes.length, i);
+        }
+    }
+}

--- a/embulk-executor-mapreduce_2_7/src/test/java/org/embulk/executor/mapreduce/TestMapReduceExecutor.java
+++ b/embulk-executor-mapreduce_2_7/src/test/java/org/embulk/executor/mapreduce/TestMapReduceExecutor.java
@@ -1,0 +1,350 @@
+package org.embulk.executor.mapreduce;
+
+import com.google.common.base.Function;
+import com.google.common.base.Strings;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Provider;
+import com.google.inject.util.Modules;
+import org.embulk.EmbulkEmbed;
+import org.embulk.RandomManager;
+import org.embulk.config.ConfigException;
+import org.embulk.config.ConfigLoader;
+import org.embulk.config.ConfigSource;
+import org.embulk.config.UserDataExceptions;
+import org.embulk.exec.PartialExecutionException;
+import org.embulk.spi.ExecutorPlugin;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.ILoggerFactory;
+import org.slf4j.impl.Log4jLoggerFactory;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Random;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.embulk.plugin.InjectedPluginSource.registerPluginTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+// this tests use Hadoop's standalone mode
+public class TestMapReduceExecutor
+{
+    private EmbulkEmbed embulk;
+    private Random random = new RandomManager(System.currentTimeMillis()).getRandom();
+
+    @Before
+    public void createResources()
+    {
+        EmbulkEmbed.Bootstrap bootstrap = new EmbulkEmbed.Bootstrap();
+
+        ConfigSource systemConfig = bootstrap.getSystemConfigLoader().newConfigSource();
+
+        if (random.nextBoolean()) {
+            systemConfig.set("embulk_factory_class", MapReduceEmbulkFactory.class.getName());
+        } else {
+            systemConfig.set("embulk_factory_class", MapReduceEmbulkFactory2.class.getName());
+        }
+
+        bootstrap.setSystemConfig(systemConfig);
+        bootstrap.overrideModules(getModuleOverrides(systemConfig));
+        embulk = bootstrap.initialize();
+
+        new File("tmp").mkdirs();
+    }
+
+    @Test
+    public void testEmbulkMapper()
+            throws Exception
+    {
+        new File("tmp/embulk_mapred_output.000.00.csv").delete();
+        new File("tmp/embulk_mapred_output.001.00.csv").delete();
+        ConfigSource config = loadConfigSource(embulk.newConfigLoader(), "config/embulk_mapred_config.yml");
+        embulk.run(config);
+        assertFileContent(
+                Lists.newArrayList(
+                        "src/test/resources/fixtures/csv/sample1.csv",
+                        "src/test/resources/fixtures/csv/sample1.csv"),
+                Lists.newArrayList(
+                        "tmp/embulk_mapred_output.000.00.csv",
+                        "tmp/embulk_mapred_output.001.00.csv"));
+    }
+
+    @Test
+    public void testEmbulkPartitioningMapperReducer()
+            throws Exception
+    {
+        new File("tmp/embulk_mapred_partitioning_output.000.00.csv").delete();
+        new File("tmp/embulk_mapred_partitioning_output.001.00.csv").delete();
+        ConfigSource config = loadConfigSource(embulk.newConfigLoader(), "config/embulk_mapred_partitioning_config.yml");
+        embulk.run(config);
+        assertFileContent(
+                Lists.newArrayList(
+                        "src/test/resources/fixtures/csv/sample1.csv",
+                        "src/test/resources/fixtures/csv/sample1.csv"),
+                Lists.newArrayList(
+                        "tmp/embulk_mapred_partitioning_output.000.00.csv",
+                        "tmp/embulk_mapred_partitioning_output.001.00.csv"));
+    }
+
+    @Test
+    public void testInvalidConfigFiles()
+            throws Exception
+    {
+        try {
+            ConfigSource config = loadConfigSource(embulk.newConfigLoader(), "config/embulk_mapred_invalid_config_files_config.yml");
+            embulk.run(config);
+            fail();
+        }
+        catch (Throwable t) {
+            assertTrue(t instanceof PartialExecutionException);
+            assertTrue(t.getCause() instanceof ConfigException);
+        }
+    }
+
+    @Test
+    public void testInvalidPartitioning()
+            throws Exception
+    {
+        try {
+            ConfigSource config = loadConfigSource(embulk.newConfigLoader(), "config/embulk_mapred_invalid_partitioning_config.yml");
+            embulk.run(config);
+            fail();
+        }
+        catch (Throwable t) {
+            assertTrue(t instanceof PartialExecutionException);
+            assertTrue(t.getCause() instanceof ConfigException);
+        }
+    }
+
+    @Test
+    public void testInvalidReducers()
+            throws Exception
+    {
+        try {
+            ConfigSource config = loadConfigSource(embulk.newConfigLoader(), "config/embulk_mapred_invalid_reducers_config.yml");
+            embulk.run(config);
+            fail();
+        }
+        catch (Throwable t) {
+            assertTrue(t instanceof PartialExecutionException);
+            assertTrue(t.getCause() instanceof ConfigException);
+        }
+    }
+
+    @Test
+    public void testInvalidLibjars()
+            throws Exception
+    {
+        try {
+            ConfigSource config = loadConfigSource(embulk.newConfigLoader(), "config/embulk_mapred_invalid_libjars_config.yml");
+            embulk.run(config);
+            fail();
+        }
+        catch (Throwable t) {
+            assertTrue(t instanceof PartialExecutionException);
+            assertTrue(t.getCause() instanceof RuntimeException);
+            assertTrue(t.getCause().getCause() instanceof FileNotFoundException);
+        }
+    }
+
+    @Test
+    public void testStopOnInvalidRecord()
+            throws Exception
+    {
+        try {
+            ConfigSource config = loadConfigSource(embulk.newConfigLoader(), "config/embulk_mapred_stop_on_invalid_record_config.yml");
+            embulk.run(config);
+            fail();
+        }
+        catch (Throwable t) {
+            t.printStackTrace();
+            assertTrue(t instanceof PartialExecutionException);
+            assertTrue(UserDataExceptions.isUserDataException(t.getCause()));
+        }
+    }
+
+    private static ConfigSource loadConfigSource(ConfigLoader configLoader, String yamlFile)
+            throws IOException
+    {
+        return configLoader.fromYaml(TestMapReduceExecutor.class.getClassLoader().getResourceAsStream(yamlFile));
+    }
+
+    private static Function<List<Module>, List<Module>> getModuleOverrides(final ConfigSource systemConfig)
+    {
+        return new Function<List<Module>, List<Module>>()
+        {
+            public List<Module> apply(List<Module> modules)
+            {
+                return overrideModules(modules, systemConfig);
+            }
+        };
+    }
+
+    private static List<Module> overrideModules(List<Module> modules, ConfigSource systemConfig)
+    {
+        return ImmutableList.of(Modules.override(Iterables.concat(modules, getAdditionalModules(systemConfig)))
+                .with(getOverrideModules(systemConfig)));
+    }
+
+    private static List<Module> getAdditionalModules(ConfigSource systemConfig)
+    {
+        return ImmutableList.<Module>of(new ExecutorPluginApplyModule());
+    }
+
+    private static List<Module> getOverrideModules(ConfigSource systemConfig)
+    {
+        return ImmutableList.<Module>of(new LoggerOverrideModule());
+    }
+
+    static class ExecutorPluginApplyModule
+            implements Module
+    {
+        @Override
+        public void configure(Binder binder)
+        {
+            registerPluginTo(binder, ExecutorPlugin.class, "mapreduce", MapReduceExecutor.class);
+        }
+    }
+
+    static class LoggerOverrideModule
+            implements Module
+    {
+        @Override
+        public void configure(Binder binder)
+        {
+            binder.bind(ILoggerFactory.class).toProvider(new Provider<ILoggerFactory>()
+            {
+                @Override
+                public ILoggerFactory get()
+                {
+                    return new Log4jLoggerFactory(); // YARN has used log4j.
+                }
+            });
+        }
+    }
+
+    public static class MapReduceEmbulkFactory
+    {
+        public EmbulkEmbed.Bootstrap bootstrap(final ConfigSource systemConfig)
+        {
+            EmbulkEmbed.Bootstrap bootstrap = new EmbulkEmbed.Bootstrap();
+            bootstrap.setSystemConfig(systemConfig);
+
+            // add modules
+            //bootstrap.addModules(ImmutableList.<Module>of());
+
+            // override modules
+            bootstrap.overrideModules(new Function<List<Module>, List<Module>>()
+            {
+                public List<Module> apply(List<Module> modules)
+                {
+                    return ImmutableList.of(Modules.override(modules).with(new LoggerOverrideModule()));
+                }
+            });
+
+            return bootstrap;
+        }
+    }
+
+    public static class MapReduceEmbulkFactory2
+    {
+        public EmbulkEmbed.Bootstrap bootstrap(final ConfigSource systemConfig, final ConfigSource executorParams)
+        {
+            EmbulkEmbed.Bootstrap bootstrap = new EmbulkEmbed.Bootstrap();
+            bootstrap.setSystemConfig(systemConfig);
+
+            // add modules
+            //bootstrap.addModules(ImmutableList.<Module>of());
+
+            // override modules
+            bootstrap.overrideModules(new Function<List<Module>, List<Module>>()
+            {
+                public List<Module> apply(List<Module> modules)
+                {
+                    return ImmutableList.of(Modules.override(modules).with(new LoggerOverrideModule()));
+                }
+            });
+
+            return bootstrap;
+        }
+    }
+
+    private static void assertFileContent(List<String> inputFiles, List<String> outputFiles)
+        throws IOException
+    {
+        List<List<String>> inputRecords = getRecords(inputFiles);
+        Collections.sort(inputRecords, new RecordComparator());
+
+        List<List<String>> outputRecords = getRecords(outputFiles);
+        Collections.sort(outputRecords, new RecordComparator());
+
+        assertEquals(inputRecords, outputRecords);
+    }
+
+    private static class RecordComparator
+            implements Comparator<List<String>>
+    {
+        @Override
+        public int compare(List<String> r1, List<String> r2)
+        {
+            return r1.get(0).compareTo(r2.get(0));
+        }
+    }
+
+    private static List<List<String>> getRecords(List<String> files)
+        throws IOException
+    {
+        List<List<String>> records = new ArrayList<>();
+
+        try {
+            for (String file : files) {
+                try (BufferedReader r = newReader(file)) {
+                    r.readLine(); // header
+                    records.addAll(getRecords(r)); // contents
+                }
+            }
+        }
+        catch (IOException e) {
+            throw Throwables.propagate(e);
+        }
+
+        return records;
+    }
+
+    private static List<List<String>> getRecords(BufferedReader reader)
+            throws IOException
+    {
+        List<List<String>> records = new ArrayList<>();
+
+        String line;
+        while (!Strings.isNullOrEmpty(line = reader.readLine())) {
+            String[] record = line.split(",");
+            records.add(Lists.newArrayList(record));
+        }
+
+        return records;
+    }
+
+    private static BufferedReader newReader(String filePath)
+        throws IOException
+    {
+        return Files.newBufferedReader(new File(filePath).toPath(), UTF_8);
+    }
+}

--- a/embulk-executor-mapreduce_2_7/src/test/java/org/embulk/executor/mapreduce/TestPageBufferWritable.java
+++ b/embulk-executor-mapreduce_2_7/src/test/java/org/embulk/executor/mapreduce/TestPageBufferWritable.java
@@ -1,0 +1,84 @@
+package org.embulk.executor.mapreduce;
+
+import org.embulk.spi.Buffer;
+import org.embulk.spi.Page;
+import org.embulk.spi.PageTestUtils;
+import org.embulk.spi.Schema;
+import org.embulk.spi.time.Timestamp;
+import org.embulk.spi.type.Types;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestPageBufferWritable
+{
+    @Rule
+    public MapReduceExecutorTestRuntime runtime = new MapReduceExecutorTestRuntime();
+
+    @Test
+    public void writeAndRead() throws IOException
+    {
+        Schema schema = Schema.builder()
+                .add("c0", Types.BOOLEAN)
+                .add("c1", Types.LONG)
+                .add("c2", Types.DOUBLE)
+                .add("c3", Types.STRING)
+                .add("c4", Types.TIMESTAMP)
+                .build();
+
+        for (Page page : PageTestUtils.buildPage(runtime.getBufferAllocator(), schema,
+                true, 2L, 3.0D, "45", Timestamp.ofEpochMilli(678L),
+                true, 2L, 3.0D, "45", Timestamp.ofEpochMilli(678L))) {
+
+            try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+                try (DataOutputStream dout = new DataOutputStream(out)) {
+                    PageWritable pw1 = new PageWritable();
+                    pw1.set(page);
+                    pw1.write(dout);
+
+                    BufferWritable bw1 = new BufferWritable();
+                    bw1.set(page.buffer());
+                    bw1.write(dout);
+                    dout.flush();
+
+                    try (DataInputStream din = new DataInputStream(new ByteArrayInputStream(out.toByteArray()))) {
+                        PageWritable pw2 = new PageWritable();
+                        pw2.readFields(din);
+
+                        BufferWritable bw2 = new BufferWritable();
+                        bw2.readFields(din);
+
+                        assertPageWritableEquals(pw1, pw2);
+                        assertBufferWritableEquals(bw1, bw2);
+                    }
+                }
+            }
+        }
+    }
+
+    static void assertPageWritableEquals(PageWritable pw1, PageWritable pw2)
+    {
+        Page p1 = pw1.get();
+        Page p2 = pw2.get();
+
+        assertEquals(p1.getStringReferences(), p2.getStringReferences());
+        assertBufferEquals(p1.buffer(), p2.buffer());
+    }
+
+    static void assertBufferWritableEquals(BufferWritable bw1, BufferWritable bw2)
+    {
+        assertBufferEquals(bw1.get(), bw2.get());
+    }
+
+    static void assertBufferEquals(Buffer b1, Buffer b2)
+    {
+        assertEquals(b1, b2);
+    }
+}

--- a/embulk-executor-mapreduce_2_7/src/test/java/org/embulk/executor/mapreduce/TestTimestampPartitioning.java
+++ b/embulk-executor-mapreduce_2_7/src/test/java/org/embulk/executor/mapreduce/TestTimestampPartitioning.java
@@ -1,0 +1,222 @@
+package org.embulk.executor.mapreduce;
+
+import org.embulk.config.ConfigException;
+import org.embulk.config.ConfigSource;
+import org.embulk.spi.Column;
+import org.embulk.spi.Page;
+import org.embulk.spi.PageReader;
+import org.embulk.spi.PageTestUtils;
+import org.embulk.spi.Schema;
+import org.embulk.spi.time.Timestamp;
+import org.embulk.spi.type.Types;
+import org.embulk.executor.mapreduce.TimestampPartitioning.LongUnixTimestampPartitioner;
+import org.embulk.executor.mapreduce.TimestampPartitioning.TimestampPartitioner;
+import org.embulk.executor.mapreduce.TimestampPartitioning.Unit;
+import org.embulk.executor.mapreduce.TimestampPartitioning.UnixTimestampUnit;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class TestTimestampPartitioning
+{
+    @Rule
+    public MapReduceExecutorTestRuntime runtime = new MapReduceExecutorTestRuntime();
+
+    private TimestampPartitioning tp;
+
+    @Before
+    public void createTimestampPartitioning()
+    {
+        tp = new TimestampPartitioning();
+    }
+
+    @Test
+    public void validateConfigSource()
+            throws IOException
+    {
+        { // specified column is not included in schema
+            ConfigSource config = runtime.getExec().newConfigSource()
+                    .set("column", "_c0").set("unit", "hour").set("timezone", "UTC");
+            Schema schema = Schema.builder().add("not_included", Types.TIMESTAMP).build();
+
+            try {
+                tp.configure(config, schema, 0);
+                fail();
+            } catch (Throwable t) {
+                assertTrue(t instanceof ConfigException);
+            }
+        }
+
+        { // only UTC is supported now
+            ConfigSource config = runtime.getExec().newConfigSource()
+                    .set("column", "_c0").set("unit", "hour").set("timezone", "PDT");
+            Schema schema = Schema.builder().add("_c0", Types.TIMESTAMP).build();
+
+            try {
+                tp.configure(config, schema, 0);
+                fail();
+            } catch (Throwable t) {
+                assertTrue(t instanceof ConfigException);
+            }
+        }
+
+        { // the unit is only 'hour' or 'day'
+            ConfigSource config = runtime.getExec().newConfigSource()
+                    .set("column", "_c0").set("unit", "invalid").set("timezone", "UTC");
+            Schema schema = Schema.builder().add("_c0", Types.TIMESTAMP).build();
+
+            try {
+                tp.configure(config, schema, 0);
+                fail();
+            } catch (Throwable t) {
+                assertTrue(t instanceof ConfigException);
+            }
+        }
+
+        { // the column type is only timestamp or long
+            ConfigSource config = runtime.getExec().newConfigSource()
+                    .set("column", "_c0").set("unit", "hour").set("timezone", "UTC");
+            Schema schema = Schema.builder().add("_c0", Types.STRING).build();
+
+            try {
+                tp.configure(config, schema, 0);
+                fail();
+            } catch (Throwable t) {
+                assertTrue(t instanceof ConfigException);
+            }
+        }
+
+        { // if the column type is long, unix_timestamp_unit is required
+            ConfigSource config = runtime.getExec().newConfigSource()
+                    .set("column", "_c0").set("unit", "hour").set("timezone", "UTC").set("unix_timestamp_unit", "invalid");
+            Schema schema = Schema.builder().add("_c0", Types.LONG).build();
+
+            try {
+                tp.configure(config, schema, 0);
+                fail();
+            } catch (Throwable t) {
+                assertTrue(t instanceof ConfigException);
+            }
+        }
+    }
+
+    @Test
+    public void comparePartitionKeys()
+            throws Exception
+    {
+        List<PartitionKey> pks = new ArrayList<>();
+
+        Column c0 = new Column(0, "c0", Types.LONG);
+        Column c1 = new Column(1, "c1", Types.TIMESTAMP);
+        Schema schema = new Schema(Arrays.asList(c0, c1));
+
+        LongUnixTimestampPartitioner lp = new LongUnixTimestampPartitioner(c0, Unit.HOUR, 1, UnixTimestampUnit.SEC);
+        TimestampPartitioner tp = new TimestampPartitioner(c1, Unit.HOUR, 1);
+
+        long timeWindow = System.currentTimeMillis()/1000/3600*3600;
+        PageReader r = new PageReader(schema);
+        for (Page page : PageTestUtils.buildPage(runtime.getBufferAllocator(), schema,
+                timeWindow, Timestamp.ofEpochSecond(timeWindow),
+                timeWindow+1, Timestamp.ofEpochSecond(timeWindow+1),
+                timeWindow+3600, Timestamp.ofEpochSecond(timeWindow+3600),
+                timeWindow+3600+1, Timestamp.ofEpochSecond(timeWindow+3600+1),
+                timeWindow+2*3600, Timestamp.ofEpochSecond(timeWindow+2*3600),
+                timeWindow+2*3600+1, Timestamp.ofEpochSecond(timeWindow+2*3600+1)
+        )){
+            r.setPage(page);
+            while (r.nextRecord()) {
+                pks.add(lp.updateKey(r).clone());
+                pks.add(tp.updateKey(r).clone());
+            }
+        }
+
+        for (int i = 0; i < pks.size(); i += 2) {
+            assertTrue(pks.get(i).equals(pks.get(i+1))); // long(tw) == timestamp(tw)
+        }
+        for (int i = 0; i < pks.size() - 4; i += 4) {
+            assertTrue(pks.get(i).equals(pks.get(i+2))); // long(tw) == long (tw+1)
+        }
+        for (int i = 0; i < pks.size() - 4; i += 4) {
+            assertFalse(pks.get(i).equals(pks.get(i+4))); // long(tw) != long (tw+3600)
+        }
+    }
+
+    @Test
+    public void checkUnit()
+    {
+        long hourlyTimeWindow = System.currentTimeMillis() / 1000 / 3600 * 3600;
+        long dailyTimeWindow = System.currentTimeMillis() / 1000 / 86400 * 86600;
+
+        // hour
+        {
+            assertEquals(Unit.HOUR, Unit.of("hour"));
+            assertTrue(Unit.HOUR.utcPartition(hourlyTimeWindow) == Unit.HOUR.utcPartition(hourlyTimeWindow + 1));
+            assertTrue(Unit.HOUR.utcPartition(hourlyTimeWindow) != Unit.HOUR.utcPartition(hourlyTimeWindow + 3600));
+        }
+
+        // day
+        {
+            assertEquals(Unit.DAY, Unit.of("day"));
+            assertTrue(Unit.DAY.utcPartition(dailyTimeWindow) == Unit.DAY.utcPartition(dailyTimeWindow + 1));
+            assertTrue(Unit.DAY.utcPartition(dailyTimeWindow) != Unit.DAY.utcPartition(dailyTimeWindow + 86400));
+        }
+
+        // invalid_unit
+        {
+            try {
+                Unit.of("invalid_unit");
+                fail();
+            } catch (Exception e) {
+                assertTrue(e instanceof ConfigException);
+            }
+        }
+    }
+
+    @Test
+    public void checkUnixTimestampUnit()
+    {
+        long currentNano = System.nanoTime();
+        long currentSec = currentNano / 1000000000;
+
+        // sec
+        {
+            assertEquals(UnixTimestampUnit.SEC, UnixTimestampUnit.of("sec"));
+            assertEquals(currentSec, UnixTimestampUnit.SEC.toSeconds(currentNano / 1000000000));
+        }
+
+        // milli
+        {
+            assertEquals(UnixTimestampUnit.MILLI, UnixTimestampUnit.of("milli"));
+            assertEquals(currentSec, UnixTimestampUnit.MILLI.toSeconds(currentNano / 1000000));
+        }
+
+        // micro
+        {
+            assertEquals(UnixTimestampUnit.MICRO, UnixTimestampUnit.of("micro"));
+            assertEquals(currentSec, UnixTimestampUnit.MICRO.toSeconds(currentNano / 1000));
+        }
+
+        // nano
+        {
+            assertEquals(UnixTimestampUnit.NANO, UnixTimestampUnit.of("nano"));
+            assertEquals(currentSec, UnixTimestampUnit.NANO.toSeconds(currentNano));
+        }
+
+        // invalid_unit
+        {
+            try {
+                UnixTimestampUnit.of("invalid_unit");
+                fail();
+            } catch (Exception e) {
+                assertTrue(e instanceof ConfigException);
+            }
+        }
+    }
+}

--- a/embulk-executor-mapreduce_2_7/src/test/resources/config/core-site.xml
+++ b/embulk-executor-mapreduce_2_7/src/test/resources/config/core-site.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+  <property>
+    <name>fs.defaultFS</name>
+    <value>file:///tmp/</value>
+  </property>
+</configuration>

--- a/embulk-executor-mapreduce_2_7/src/test/resources/config/embulk_mapred_config.yml
+++ b/embulk-executor-mapreduce_2_7/src/test/resources/config/embulk_mapred_config.yml
@@ -1,0 +1,49 @@
+exec:
+  type: mapreduce
+  config_files:
+  - src/test/resources/config/core-site.xml
+  - src/test/resources/config/hdfs-site.xml
+  - src/test/resources/config/mapred-site.xml
+  config:
+    k1: v1
+    k2: v2
+  state_path: 'file:///tmp/embulk/'
+  job_name: embulk_mapred_0001
+  exclude_jars:
+  - '*log4j-over-slf4j*'
+in:
+  type: file
+  path_prefix: src/test/resources/fixtures/csv/sample
+  parser:
+    charset: UTF-8
+    newline: CRLF
+    type: csv
+    delimiter: ','
+    quote: '"'
+    escape: '"'
+    skip_header_lines: 1
+    columns:
+    - {name: timestamp, type: timestamp, format: "%Y-%m-%d %H:%M:%S"}
+    - {name: host, type: string}
+    - {name: path, type: string}
+    - {name: method, type: string}
+    - {name: referer, type: string}
+    - {name: code, type: long}
+    - {name: agent, type: string}
+    - {name: user, type: string}
+    - {name: size, type: long}
+    - {name: d, type: double}
+    - {name: flag, type: boolean}
+    - {name: v_json, type: json}
+out:
+  type: file
+  path_prefix: 'tmp/embulk_mapred_output.'
+  file_ext: 'csv'
+  formatter:
+    charset: UTF-8
+    newline: CRLF
+    quote: '"'
+    escape: '"'
+    type: csv
+    column_options:
+      timestamp: {format: '%Y-%m-%d %H:%M:%S'}

--- a/embulk-executor-mapreduce_2_7/src/test/resources/config/embulk_mapred_invalid_config_files_config.yml
+++ b/embulk-executor-mapreduce_2_7/src/test/resources/config/embulk_mapred_invalid_config_files_config.yml
@@ -1,0 +1,38 @@
+exec:
+  type: mapreduce
+  config_files:
+  - src/test/resources/config/invalid-core-site.xml
+  - src/test/resources/config/invalid-hdfs-site.xml
+  - src/test/resources/config/invalid-mapred-site.xml
+  config:
+    k1: v1
+    k2: v2
+  state_path: 'file:///tmp/embulk/'
+  job_name: embulk_mapred_0001
+  exclude_jars:
+  - '*log4j-over-slf4j*'
+in:
+  type: file
+  path_prefix: src/test/resources/fixtures/csv/sample
+  parser:
+    charset: UTF-8
+    newline: CRLF
+    type: csv
+    delimiter: ','
+    quote: ''
+    escape: ''
+    skip_header_lines: 1
+    columns:
+    - {name: timestamp, type: timestamp, format: "%Y-%m-%d %H:%M:%S"}
+    - {name: host, type: string}
+    - {name: path, type: string}
+    - {name: method, type: string}
+    - {name: referer, type: string}
+    - {name: code, type: long}
+    - {name: agent, type: string}
+    - {name: user, type: string}
+    - {name: size, type: long}
+    - {name: d, type: double}
+    - {name: flag, type: boolean}
+out:
+  type: stdout

--- a/embulk-executor-mapreduce_2_7/src/test/resources/config/embulk_mapred_invalid_libjars_config.yml
+++ b/embulk-executor-mapreduce_2_7/src/test/resources/config/embulk_mapred_invalid_libjars_config.yml
@@ -1,0 +1,40 @@
+exec:
+  type: mapreduce
+  config_files:
+  - src/test/resources/config/core-site.xml
+  - src/test/resources/config/hdfs-site.xml
+  - src/test/resources/config/mapred-site.xml
+  config:
+    k1: v1
+    k2: v2
+  state_path: 'file:///tmp/embulk/'
+  job_name: embulk_mapred_0001
+  libjars:
+  - invalid_jar
+  exclude_jars:
+  - '*log4j-over-slf4j*'
+in:
+  type: file
+  path_prefix: src/test/resources/fixtures/csv/sample
+  parser:
+    charset: UTF-8
+    newline: CRLF
+    type: csv
+    delimiter: ','
+    quote: ''
+    escape: ''
+    skip_header_lines: 1
+    columns:
+    - {name: timestamp, type: timestamp, format: "%Y-%m-%d %H:%M:%S"}
+    - {name: host, type: string}
+    - {name: path, type: string}
+    - {name: method, type: string}
+    - {name: referer, type: string}
+    - {name: code, type: long}
+    - {name: agent, type: string}
+    - {name: user, type: string}
+    - {name: size, type: long}
+    - {name: d, type: double}
+    - {name: flag, type: boolean}
+out:
+  type: stdout

--- a/embulk-executor-mapreduce_2_7/src/test/resources/config/embulk_mapred_invalid_partitioning_config.yml
+++ b/embulk-executor-mapreduce_2_7/src/test/resources/config/embulk_mapred_invalid_partitioning_config.yml
@@ -1,0 +1,40 @@
+exec:
+  type: mapreduce
+  config_files:
+  - src/test/resources/config/core-site.xml
+  - src/test/resources/config/hdfs-site.xml
+  - src/test/resources/config/mapred-site.xml
+  config:
+    k1: v1
+    k2: v2
+  partitioning:
+    type: long
+  state_path: 'file:///tmp/embulk/'
+  job_name: embulk_mapred_partitioning_0001
+  exclude_jars:
+  - '*log4j-over-slf4j*'
+in:
+  type: file
+  path_prefix: src/test/resources/fixtures/csv/sample
+  parser:
+    charset: UTF-8
+    newline: CRLF
+    type: csv
+    delimiter: ','
+    quote: ''
+    escape: ''
+    skip_header_lines: 1
+    columns:
+    - {name: timestamp, type: timestamp, format: "%Y-%m-%d %H:%M:%S"}
+    - {name: host, type: string}
+    - {name: path, type: string}
+    - {name: method, type: string}
+    - {name: referer, type: string}
+    - {name: code, type: long}
+    - {name: agent, type: string}
+    - {name: user, type: string}
+    - {name: size, type: long}
+    - {name: d, type: double}
+    - {name: flag, type: boolean}
+out:
+  type: stdout

--- a/embulk-executor-mapreduce_2_7/src/test/resources/config/embulk_mapred_invalid_reducers_config.yml
+++ b/embulk-executor-mapreduce_2_7/src/test/resources/config/embulk_mapred_invalid_reducers_config.yml
@@ -1,0 +1,44 @@
+exec:
+  type: mapreduce
+  config_files:
+  - src/test/resources/config/core-site.xml
+  - src/test/resources/config/hdfs-site.xml
+  - src/test/resources/config/mapred-site.xml
+  config:
+    k1: v1
+    k2: v2
+  partitioning:
+    type: timestamp
+    unit: hour
+    column: timestamp
+    unix_timestamp_unit: sec
+  reducers: -1
+  state_path: 'file:///tmp/embulk/'
+  job_name: embulk_mapred_0001
+  exclude_jars:
+  - '*log4j-over-slf4j*'
+in:
+  type: file
+  path_prefix: src/test/resources/fixtures/csv/sample
+  parser:
+    charset: UTF-8
+    newline: CRLF
+    type: csv
+    delimiter: ','
+    quote: ''
+    escape: ''
+    skip_header_lines: 1
+    columns:
+    - {name: timestamp, type: timestamp, format: "%Y-%m-%d %H:%M:%S"}
+    - {name: host, type: string}
+    - {name: path, type: string}
+    - {name: method, type: string}
+    - {name: referer, type: string}
+    - {name: code, type: long}
+    - {name: agent, type: string}
+    - {name: user, type: string}
+    - {name: size, type: long}
+    - {name: d, type: double}
+    - {name: flag, type: boolean}
+out:
+  type: stdout

--- a/embulk-executor-mapreduce_2_7/src/test/resources/config/embulk_mapred_partitioning_config.yml
+++ b/embulk-executor-mapreduce_2_7/src/test/resources/config/embulk_mapred_partitioning_config.yml
@@ -1,0 +1,55 @@
+exec:
+  type: mapreduce
+  config_files:
+  - src/test/resources/config/core-site.xml
+  - src/test/resources/config/hdfs-site.xml
+  - src/test/resources/config/mapred-site.xml
+  config:
+    k1: v1
+    k2: v2
+  partitioning:
+    type: timestamp
+    unit: hour
+    column: timestamp
+    unix_timestamp_unit: sec
+  state_path: 'file:///tmp/embulk/'
+  job_name: embulk_mapred_partitioning_0001
+  exclude_jars:
+  - '*log4j-over-slf4j*'
+  map_side_partition_split: 2
+in:
+  type: file
+  path_prefix: src/test/resources/fixtures/csv/sample
+  parser:
+    charset: UTF-8
+    newline: CRLF
+    type: csv
+    delimiter: ','
+    quote: '"'
+    escape: '"'
+    skip_header_lines: 1
+    columns:
+    - {name: timestamp, type: timestamp, format: "%Y-%m-%d %H:%M:%S"}
+    - {name: host, type: string}
+    - {name: path, type: string}
+    - {name: method, type: string}
+    - {name: referer, type: string}
+    - {name: code, type: long}
+    - {name: agent, type: string}
+    - {name: user, type: string}
+    - {name: size, type: long}
+    - {name: d, type: double}
+    - {name: flag, type: boolean}
+    - {name: v_json, type: json}
+out:
+  type: file
+  path_prefix: 'tmp/embulk_mapred_partitioning_output.'
+  file_ext: 'csv'
+  formatter:
+    charset: UTF-8
+    newline: CRLF
+    quote: '"'
+    escape: '"'
+    type: csv
+    column_options:
+      timestamp: {format: '%Y-%m-%d %H:%M:%S'}

--- a/embulk-executor-mapreduce_2_7/src/test/resources/config/embulk_mapred_stop_on_invalid_record_config.yml
+++ b/embulk-executor-mapreduce_2_7/src/test/resources/config/embulk_mapred_stop_on_invalid_record_config.yml
@@ -1,0 +1,39 @@
+exec:
+  type: mapreduce
+  config_files:
+  - src/test/resources/config/core-site.xml
+  - src/test/resources/config/hdfs-site.xml
+  - src/test/resources/config/mapred-site.xml
+  config:
+    k1: v1
+    k2: v2
+  state_path: 'file:///tmp/embulk/'
+  job_name: embulk_mapred_0001
+  exclude_jars:
+  - '*log4j-over-slf4j*'
+in:
+  type: file
+  path_prefix: src/test/resources/fixtures/invalid_csv/sample
+  parser:
+    charset: UTF-8
+    newline: CRLF
+    type: csv
+    delimiter: ','
+    quote: ''
+    escape: ''
+    skip_header_lines: 1
+    stop_on_invalid_record: true
+    columns:
+    - {name: timestamp, type: timestamp, format: "%Y-%m-%d %H:%M:%S"}
+    - {name: host, type: string}
+    - {name: path, type: string}
+    - {name: method, type: string}
+    - {name: referer, type: string}
+    - {name: code, type: long}
+    - {name: agent, type: string}
+    - {name: user, type: string}
+    - {name: size, type: long}
+    - {name: d, type: double}
+    - {name: flag, type: boolean}
+out:
+  type: stdout

--- a/embulk-executor-mapreduce_2_7/src/test/resources/config/hdfs-site.xml
+++ b/embulk-executor-mapreduce_2_7/src/test/resources/config/hdfs-site.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+  <property>
+   <name>dfs.replication</name>
+   <value>1</value>
+  </property>
+
+  <property>
+    <name>dfs.name.dir</name>
+    <value>file:///tmp/hdfs/namenode</value>
+  </property>
+
+  <property>
+    <name>dfs.data.dir</name>
+    <value>file:///tmp/hdfs/datanode</value>
+  </property>
+</configuration>

--- a/embulk-executor-mapreduce_2_7/src/test/resources/config/mapred-site.xml
+++ b/embulk-executor-mapreduce_2_7/src/test/resources/config/mapred-site.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+  <property>
+    <name>mapreduce.framework.name</name>
+    <value>local</value>
+  </property>
+</configuration>

--- a/embulk-executor-mapreduce_2_7/src/test/resources/fixtures/csv/sample1.csv
+++ b/embulk-executor-mapreduce_2_7/src/test/resources/fixtures/csv/sample1.csv
@@ -1,0 +1,3 @@
+timestamp,host,path,method,referer,code,agent,user,size,d,flag,v_json
+2014-10-02 22:15:39,84.186.29.187,/category/electronics,GET,/category/music,200,Mozilla/5.0,-,136,1.1,true,"{""k0"":""v0"",""k1"":""v1""}"
+2014-10-02 22:15:01,140.36.216.47,/category/music?from=10,GET,-,200,Mozilla/5.0,-,70,1.2,false,"[1,2,""3""]"

--- a/embulk-executor-mapreduce_2_7/src/test/resources/fixtures/csv/sample2.csv
+++ b/embulk-executor-mapreduce_2_7/src/test/resources/fixtures/csv/sample2.csv
@@ -1,0 +1,3 @@
+timestamp,host,path,method,referer,code,agent,user,size,d,flag,v_json
+2014-10-02 22:15:39,84.186.29.187,/category/electronics,GET,/category/music,200,Mozilla/5.0,-,136,1.1,true,"{""k0"":""v0"",""k1"":""v1""}"
+2014-10-02 22:15:01,140.36.216.47,/category/music?from=10,GET,-,200,Mozilla/5.0,-,70,1.2,false,"[1,2,""3""]"

--- a/embulk-executor-mapreduce_2_7/src/test/resources/fixtures/invalid_csv/sample1.csv
+++ b/embulk-executor-mapreduce_2_7/src/test/resources/fixtures/invalid_csv/sample1.csv
@@ -1,0 +1,4 @@
+embulk-executor-mapreduce/src/test/resources/fixtures/invalid_csv/sample2.csv timestamp,host,path,method,referer,code,agent,user,size,d,flag
+2014-10-02 22:15:39,84.186.29.187,/category/electronics,GET,/category/music,mapred,Mozilla/5.0,-,136,1.1,true
+2014-10-02 22:15:01,140.36.216.47,/category/music?from=10,GET,-,200,Mozilla/5.0,-,70,1.2,false
+

--- a/embulk-executor-mapreduce_2_7/src/test/resources/fixtures/invalid_csv/sample2.csv
+++ b/embulk-executor-mapreduce_2_7/src/test/resources/fixtures/invalid_csv/sample2.csv
@@ -1,0 +1,3 @@
+timestamp,host,path,method,referer,code,agent,user,size,d,flag
+2014-10-02 22:15:39,84.186.29.187,/category/electronics,GET,/category/music,200,Mozilla/5.0,-,136,1.1,true
+2014-10-02 22:15:01,140.36.216.47,/category/music?from=10,GET,-,200,Mozilla/5.0,-,70,1.2,false

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,3 @@
 rootProject.name = 'embulk-executor-mapreduce-root'
 include 'embulk-executor-mapreduce'
+include 'embulk-executor-mapreduce_2_7'


### PR DESCRIPTION
@muga After #39, this tries to add embulk-executor-mapreduce_2_7 depending on `org.apache.hadoop:hadoop-client:2.7.3`.

Because the source code are totally the same, we may have another better approach only within `build.gradle`, though.