### PR TITLE
Release v0.4.0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+Release 0.4.0 - 2017-09-05
+
+* Split embulk-executor-mapreduce to _2_6 (for Hadoop 2.6.*) and _2_7 (for Hadoop 2.7.*).
+
 
 Release 0.3.0 - 2017-06-27
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ import com.github.jrubygradle.JRubyExec
 
 allprojects {
     group = 'org.embulk.executor.mapreduce'
-    version = '0.3.0'
+    version = '0.4.0'
 }
 
 subprojects {


### PR DESCRIPTION
@muga Can you have a look?

We have had no releases after splitting into `_2_6` and `_2_7`. Maybe nicer to have a new second digit though no contents have changed.